### PR TITLE
taxonomie_display_field_name --> taxonomy_display_field_name

### DIFF
--- a/data/migration/migration_0.1.0_0.1.1.sql
+++ b/data/migration/migration_0.1.0_0.1.1.sql
@@ -13,7 +13,7 @@ ALTER TABLE gn_monitoring.t_module_complements ADD CONSTRAINT fk_t_module_comple
             ON UPDATE CASCADE ON DELETE CASCADE;
 
 ALTER TABLE gn_monitoring.t_module_complements ADD COLUMN b_synthese BOOLEAN DEFAULT TRUE;
-ALTER TABLE gn_monitoring.t_module_complements ADD COLUMN taxonomie_display_field_name CHARACTER VARYING DEFAULT 'nom_vern,lb_nom';
+ALTER TABLE gn_monitoring.t_module_complements ADD COLUMN taxonomy_display_field_name CHARACTER VARYING DEFAULT 'nom_vern,lb_nom';
 
 
 -- create update date for t_modules complements 


### PR DESCRIPTION
Je ne sais pas trop où est défini le champs taxonomie_display_field_name, mais cela provoque une erreur
>   File "/home/geonatureadmin/GeoNature/external_modules/monitorings/backend/modules/repositories.py", line 97, in get_modules
>     raise GeoNatureError("MONITORINGS - get_modules : {}".format(str(e)))
> geonature.utils.errors.GeoNatureError: MONITORINGS - get_modules : (psycopg2.errors.UndefinedColumn) column t_module_complements.taxonomy_display_field_name does not exist
> LINE 1: ...monitoring_t_module_complements_id_list_taxonomy, gn_monitor...
>                                                              ^
> HINT:  Perhaps you meant to reference the column "t_module_complements.taxonomie_display_field_name".
> 
> [SQL: SELECT gn_monitoring.t_module_complements.id_module AS gn_monitoring_t_module_complements_id_module, gn_commons.t_modules.id_module AS gn_commons_t_modules_id_module, gn_commons.t_modules.module_code AS gn_commons_t_modules_module_code, gn_commons.t_modules.module_label AS gn_commons_t_modules_module_label, gn_commons.t_modules.module_picto AS gn_commons_t_modules_module_picto, gn_commons.t_modules.module_desc AS gn_commons_t_modules_module_desc, gn_commons.t_modules.module_group AS gn_commons_t_modules_module_group, gn_commons.t_modules.module_path AS gn_commons_t_modules_module_path, gn_commons.t_modules.module_external_url AS gn_commons_t_modules_module_external_url, gn_commons.t_modules.module_target AS gn_commons_t_modules_module_target, gn_commons.t_modules.module_comment AS gn_commons_t_modules_module_comment, gn_commons.t_modules.active_frontend AS gn_commons_t_modules_active_frontend, gn_commons.t_modules.active_backend AS gn_commons_t_modules_active_backend, gn_commons.t_modules.module_doc_url AS gn_commons_t_modules_module_doc_url, gn_commons.t_modules.module_order AS gn_commons_t_modules_module_order, gn_monitoring.t_module_complements.uuid_module_complement AS gn_monitoring_t_module_complements_uuid_module_complement, gn_monitoring.t_module_complements.id_list_observer AS gn_monitoring_t_module_complements_id_list_observer, gn_monitoring.t_module_complements.id_list_taxonomy AS gn_monitoring_t_module_complements_id_list_taxonomy, gn_monitoring.t_module_complements.taxonomy_display_field_name AS gn_monitoring_t_module_complements_taxonomy_display_field_1, gn_monitoring.t_module_complements.b_synthese AS gn_monitoring_t_module_complements_b_synthese, gn_monitoring.t_module_complements.meta_create_date AS gn_monitoring_t_module_complements_meta_create_date, gn_monitoring.t_module_complements.meta_update_date AS gn_monitoring_t_module_complements_meta_update_date 
> FROM gn_commons.t_modules JOIN gn_monitoring.t_module_complements ON gn_commons.t_modules.id_module = gn_monitoring.t_module_complements.id_module]
> (Background on this error at: http://sqlalche.me/e/13/f405)
> [2020-10-09 10:44:02 +0200] [24113] [ERROR] 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.