### PR TITLE
Liste des champs retournés par le service list est configurable

### DIFF
--- a/backend/monitoring/repositories.py
+++ b/backend/monitoring/repositories.py
@@ -225,11 +225,19 @@ class MonitoringObject(MonitoringObjectSerializer):
 
         order_by = args.getlist('order_by')
 
-
-
         req = (
             DB.session.query(Model)
         )
+
+        # Traitement de la liste des colonnes à retourner
+        fields_list = args.getlist("fields")
+        props = self.properties_names()
+        if not fields_list:
+            # TODO check if self.properties_names() == props et rel
+            fields_list = props
+        else:
+            fields_list = [field for field in fields_list if field in props]
+
 
         # filtres params get
         for key in args:
@@ -259,12 +267,10 @@ class MonitoringObject(MonitoringObjectSerializer):
             .limit(limit)
             .all()
         )
-        # TODO check if self.properties_names() == props et rel
-        props = self.properties_names()
 
         # patch order by number
         out = [
-            r.as_dict(True, columns=props, relationships=props)
+            r.as_dict(fields=fields_list)
             for r in res
         ]
 

--- a/config/monitoring/generic/site.json
+++ b/config/monitoring/generic/site.json
@@ -60,7 +60,7 @@
       "type_util": "sites_group",
       "keyValue": "id_sites_group",
       "keyLabel": "sites_group_name",
-      "api": "__MONITORINGS_PATH/list/__MODULE.MODULE_CODE/sites_group?id_module=__MODULE.ID_MODULE",
+      "api": "__MONITORINGS_PATH/list/__MODULE.MODULE_CODE/sites_group?id_module=__MODULE.ID_MODULE&fields=id_sites_group",
       "application": "GeoNature",
       "required": false,
       "hidden": true

--- a/config/monitoring/generic/site.json
+++ b/config/monitoring/generic/site.json
@@ -60,7 +60,7 @@
       "type_util": "sites_group",
       "keyValue": "id_sites_group",
       "keyLabel": "sites_group_name",
-      "api": "__MONITORINGS_PATH/list/__MODULE.MODULE_CODE/sites_group?id_module=__MODULE.ID_MODULE&fields=id_sites_group",
+      "api": "__MONITORINGS_PATH/list/__MODULE.MODULE_CODE/sites_group?id_module=__MODULE.ID_MODULE&fields=id_sites_group&fields=sites_group_name",
       "application": "GeoNature",
       "required": false,
       "hidden": true

--- a/docs/sous_module.rst
+++ b/docs/sous_module.rst
@@ -326,7 +326,7 @@ Par exemple :
         "type_util": "sites_group",
         "keyValue": "id_sites_group",
         "keyLabel": "sites_group_name",
-        "api": "__MONITORINGS_PATH/list/__MODULE.MODULE_CODE/sites_group?id_module=__MODULE.ID_MODULE",
+        "api": "__MONITORINGS_PATH/list/__MODULE.MODULE_CODE/sites_group?id_module=__MODULE.ID_MODULE&fields=id_sites_group&fields=sites_group_name"",
         "application": "GeoNature"
     },
 

--- a/frontend/app/services/config.service.ts
+++ b/frontend/app/services/config.service.ts
@@ -94,7 +94,7 @@ export class ConfigService {
     try {
       func = eval(s);
     } catch (error) {
-      console.error(`Erreur dans la définition de la fonction ${error}`);
+      console.error(`Erreur dans la définition de la fonction ${error} ${s}`);
     }
 
     return func;


### PR DESCRIPTION
La route monitorings/list retourne maintenant soit la liste des champs demandée via le paramètre fields soit l'ensemble des champs de l'objet (sans récursivité)