### PR TITLE
Design monitoring-properties

### DIFF
--- a/frontend/app/components/monitoring-properties/monitoring-properties.component.css
+++ b/frontend/app/components/monitoring-properties/monitoring-properties.component.css
@@ -1,5 +1,13 @@
+table {
+  font-size: small;
+}
+
 th {
   text-align: right;
+}
+
+.key {
+  font-weight: bold;
 }
 
 td {

--- a/frontend/app/components/monitoring-properties/monitoring-properties.component.html
+++ b/frontend/app/components/monitoring-properties/monitoring-properties.component.html
@@ -35,7 +35,7 @@
     >
       <table class="table table-striped table-sm">
         <tr *ngFor="let fieldName of obj.template['fieldNames']; let i = index">
-          <th>
+          <td style="width:50%" class="key text-muted">
             {{ obj.template.fieldLabels[fieldName] }}
             <i
               *ngIf="obj.template['fieldDefinitions'][fieldName]"
@@ -48,8 +48,8 @@
               matTooltipPosition="above"
               >help</i
             >
-          </th>
-          <td>{{ obj.resolvedProperties[fieldName] }}</td>
+          </td>
+          <td class="td-value" >{{ obj.resolvedProperties[fieldName] }}</td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
Un petite PR de style sur le composant "properties":
- alignement des propriété et valeur à gauche
- diminution de la taille du tableau
- passage en text-muted pour le propriété
Avant : 
![monitoring_properties_before](https://user-images.githubusercontent.com/15265745/157276409-c8398b74-fd13-4a77-9743-5bed7a20d493.png)
Après : 
![monitoring_propertie_after](https://user-images.githubusercontent.com/15265745/157276455-0eb05911-53d0-409d-abad-a2b2d3c9ff6b.png)

