### PR TITLE
Fix/export

### DIFF
--- a/backend/routes/monitoring.py
+++ b/backend/routes/monitoring.py
@@ -220,9 +220,11 @@ def export_all_observations(module_code, type, method,jd):
     )
     columns = view.tableDef.columns
     q = DB.session.query(*columns)
-    #data = q.all()
-    #----------------------------
-    data = DB.session.query(*columns).filter(columns.id_dataset == jd).all()
+
+    if "dataset" in columns:
+        data =q.filter(columns.id_dataset == jd)
+    data = q.all()
+    
     #-------------------------------------
 
     filename = module_code+"_"+method+"_"+dt.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S")


### PR DESCRIPTION
Certains exports ne dispose pas du champs `id_dataset`. Par exemple si je propose un export des "sites".
Cette petite correction vérifie si `id_dataset` fait partie des champs de la vue.
Par contre, en interface on a quoi qu'il arrive le champs "JDD"...