### PR TITLE
Update utils.py - bind module_code to export

### DIFF
--- a/backend/command/utils.py
+++ b/backend/command/utils.py
@@ -64,6 +64,7 @@ def process_export_csv(module_code=None):
                         open(Path(root) / f, 'r')
                         .read()
                     ).execution_options(autocommit=True)
+                    .bindparams(module_code=module_code)
                 )
                 print('{} - export csv file : {}'.format(module_code, f))
 


### PR DESCRIPTION
Comme évoqué dans #168, proposition d'évolution pour transmettre le nom du module aux différents fichiers `export.sql` comme c'est déjà le cas avec le fichier `synthese.sql`.
La variable dans le fichier d'export doit être noté de la manière suivante : `:module_code`.
La contrainte, que je ne parviens pas à contourner pour le moment, est que la variable ne peut pas être un élément constitutif d'un mot tel que le nom de la `view` comme c'est le cas dans le fichier de synthèse.
Pour avoir un fonctionnement identique au fichier de synthèse, il faudrait peut-être utilisé une commande système `psql` plutôt que `SQLAlchemy`.