### PR TITLE
Trier les sous-modules par nom

### DIFF
--- a/backend/modules/repositories.py
+++ b/backend/modules/repositories.py
@@ -87,7 +87,7 @@ def get_modules():
 
     try:
         res = (
-            DB.session.query(TMonitoringModules)
+            DB.session.query(TMonitoringModules).order_by(TMonitoringModules.module_label)
             .all()
         )
 


### PR DESCRIPTION
Je commence à avoir pas mal de sous-modules et je propose ce petit rajout pour pouvoir les trier par le nom de sous-module Après, à voir pour le mettre dans le fichier .toml pour trier via un autre champ comme le module_code....