### PR TITLE
fix export_all_observations when specific id_dataset is given or not

### DIFF
--- a/backend/gn_module_monitoring/routes/monitoring.py
+++ b/backend/gn_module_monitoring/routes/monitoring.py
@@ -250,7 +250,7 @@ def export_all_observations(module_code, method):
 
     :returns: Array of dict
     """
-    id_dataset = request.args.get("id_dataset", int, None)
+    id_dataset = request.args.get("id_dataset", None, int)
 
     view = GenericTableGeo(
         tableName=f"v_export_{module_code.lower()}_{method}",
@@ -261,7 +261,7 @@ def export_all_observations(module_code, method):
     q = DB.session.query(*columns)
     # Filter with dataset if is set
     if hasattr(columns, "id_dataset") and id_dataset:
-        data = q.filter(columns.id_dataset == id_dataset)
+        q = q.filter(columns.id_dataset == id_dataset)
     data = q.all()
 
     timestamp = dt.datetime.now().strftime("%Y_%m_%d_%Hh%Mm%S")


### PR DESCRIPTION
J'ai voulu utiliser la variable `"filter_dataset": true` de l'objet `export_csv` dans les fichiers `module.json` et je me suis aperçu
que peu importe le jdd sélectionné, le csv extrait contient toutes les données.

En regardant de plus près, il m'a semblé qu'il y avait une coquille dans l'attribution du filtre (`l.251`). J'ai d'ailleurs hésité à l'écrire différemment (ci-dessous ce que j'avais en tête) pour éviter de réattribuer l'objet `q` à lui-même. A voir ce que vous préférez comme écriture.
``` py
    data = (q.filter(columns.id_dataset == id_dataset).all()
            if hasattr(columns, "id_dataset") and id_dataset
            else q.all())
```

Une inversion était également présente dans la récupération de `id_dataset`, entre la valeur par défaut et le type de l'argument récupéré.