### PR TITLE
Creation des permissions disponibles à partir de l'objet tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,15 @@ Les permissions ne sont implémentées que partiellement. La notion de portée (
 
 La gestion des permissions pour les rôles (utilisateur ou groupe) se réalise au niveau de l'interface d'administration des permissions de GeoNature.
 
-Il est possible de spécifier les permissions pour chaque type d'objet (groupes de sites, sites, visites et observations).
+Les permissions sont définis pour chaque type d'objet (modules, groupes de sites, sites, visites et observations) :
+ * MONITORINGS_MODULES - R : permet a l'utilisateur d'accéder au module, de le voir dans la liste des modules
+ * MONITORINGS_MODULES - U : action administrateur qui permet de configurer le module et de synchroniser la synthèse
+ * MONITORINGS_MODULES - E : action qui permet aux utilisateurs d'exporter les données (si défini par le module)
+ * MONITORINGS_GRP_SITES - CRUD : action de lire, créer, modifier, supprimer un groupe de site
+ * MONITORINGS_SITES - CRUD : action de lire, créer, modifier, supprimer un site
+ * MONITORINGS_VISITES - CRUD : action de lire, créer, modifier, supprimer les visites, observations, observations détails
 
-Si aucune permission n'est associée à l'objet, les permissions auront comme valeur celles associées au sous-module.
+Par défaut, dès qu'un utilisateur a un droit supérieur à 0 pour une action (c-a-d aucune portée) il peut réaliser cette action.
 
-Par défaut, dès qu'un utilisateur a un droit supérieur à 0 pour une action (c-a-d aucune portée) il peut réaliser cette action. Il est possible de surcharger les paramètres au niveau des fichiers de configuration des objets du module. (cf doc de configuration des sous-modules).
+
+Il est possible de mettre à jour les permissions disponibles pour un module en utilisant la commande `update_module_available_permissions`

--- a/backend/gn_module_monitoring/command/utils.py
+++ b/backend/gn_module_monitoring/command/utils.py
@@ -100,12 +100,12 @@ def process_available_permissions(module_code):
 
     tree = config.get("tree", [])
 
-    module_object = [k for k in extract_keys(tree, keys=[])]
+    module_objects = [k for k in extract_keys(tree, keys=[])]
 
     permission_level = current_app.config["MONITORINGS"].get("PERMISSION_LEVEL", {})
 
     # Insert permission object
-    for permission_object_code in module_object:
+    for permission_object_code in module_objects:
         print(f"Création des permissions pour {module_code} : {permission_object_code}")
         insert_module_available_permissions(module_code, permission_level[permission_object_code])
 

--- a/backend/gn_module_monitoring/command/utils.py
+++ b/backend/gn_module_monitoring/command/utils.py
@@ -1,11 +1,13 @@
 import os
 from pathlib import Path
+
+from flask import current_app
 from sqlalchemy import and_, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
 from geonature.utils.env import DB, BACKEND_DIR
-from geonature.core.gn_permissions.models import PermObject
+from geonature.core.gn_permissions.models import PermObject, PermissionAvailable, PermAction
 from geonature.core.gn_commons.models import TModules
 
 from pypnnomenclature.models import TNomenclatures, BibNomenclaturesTypes
@@ -16,11 +18,28 @@ from ..config.repositories import get_config
 
 from ..modules.repositories import get_module, get_source_by_code, get_modules
 
+
 """
 utils.py
 
 fonctions pour les commandes du module monitoring
 """
+
+
+PERMISSION_LABEL = {
+    "MONITORINGS_MODULES": {"label": "modules", "actions": ["R", "U", "E"]},
+    "MONITORINGS_GRP_SITES": {"label": "groupes de sites", "actions": ["C", "R", "U", "D"]},
+    "MONITORINGS_SITES": {"label": "sites", "actions": ["C", "R", "U", "D"]},
+    "MONITORINGS_VISITES": {"label": "visites", "actions": ["C", "R", "U", "D"]},
+}
+
+ACTION_LABEL = {
+    "C": "Créer des",
+    "R": "Voir les",
+    "U": "Modifier les",
+    "D": "Supprimer des",
+    "E": "Exporter les",
+}
 
 
 def process_for_all_module(process_func):
@@ -32,12 +51,6 @@ def process_for_all_module(process_func):
     for module in get_modules():
         process_func(module.module_code)
     return
-
-
-def getMonitoringPermissionObjectLabel_dict():
-    return __import__(
-        "gn_module_monitoring"
-    ).monitoring.definitions.MonitoringPermissionObjectLabel_dict
 
 
 def process_export_csv(module_code=None):
@@ -85,19 +98,20 @@ def process_available_permissions(module_code):
         print(f"Il y a un problème de configuration pour le module {module_code}")
         return
 
-    insert_module_available_permissions(module_code, "ALL")
+    tree = config.get("tree", [])
+
+    module_object = [k for k in extract_keys(tree, keys=[])]
+
+    permission_level = current_app.config["MONITORINGS"].get("PERMISSION_LEVEL", {})
 
     # Insert permission object
-    for permission_object_code in config.get("permission_objects", []):
-        insert_module_available_permissions(module_code, permission_object_code)
+    for permission_object_code in module_object:
+        print(f"Création des permissions pour {module_code} : {permission_object_code}")
+        insert_module_available_permissions(module_code, permission_level[permission_object_code])
 
 
 def insert_module_available_permissions(module_code, perm_object_code):
-    print(
-        f"process permissions for (module_code, perm_object)= ({module_code},{perm_object_code})"
-    )
-
-    object_label = getMonitoringPermissionObjectLabel_dict().get(perm_object_code)
+    object_label = PERMISSION_LABEL.get(perm_object_code)["label"]
 
     if not object_label:
         print(f"L'object {perm_object_code} n'est pas traité")
@@ -124,31 +138,24 @@ def insert_module_available_permissions(module_code, perm_object_code):
     """
     DB.engine.execution_options(autocommit=True).execute(txt_cor_object_module)
 
-    txt_perm_available = f"""
-        INSERT INTO gn_permissions.t_permissions_available (
-                id_module,
-                id_object,
-                id_action,
-                label,
-                scope_filter)
-        SELECT
-            {module.id_module},
-            {perm_object.id_object},
-            a.id_action,
-            v.label,
-            true
-        FROM
-            ( VALUES
-                ('C', 'Créer des {object_label}'),
-                ('R', 'Voir les {object_label}'),
-                ('U', 'Modifier les {object_label}'),
-                ('D', 'Supprimer des {object_label}'),
-                ('E', 'Exporter les {object_label}')
-            ) AS v (action_code, label)
-        JOIN gn_permissions.bib_actions a ON v.action_code = a.code_action
-        ON CONFLICT DO NOTHING
-        """
-    DB.engine.execution_options(autocommit=True).execute(txt_perm_available)
+    # Création d'une permission disponible pour chaque action
+    object_actions = PERMISSION_LABEL.get(perm_object_code)["actions"]
+    for action in object_actions:
+        permaction = PermAction.query.filter_by(code_action=action).one()
+        try:
+            perm = PermissionAvailable.query.filter_by(
+                module=module, object=perm_object, action=permaction
+            ).one()
+        except NoResultFound:
+            perm = PermissionAvailable(
+                module=module,
+                object=perm_object,
+                action=permaction,
+                label=f"{ACTION_LABEL[action]} {object_label}",
+                scope_filter=True,
+            )
+            DB.session.add(perm)
+    DB.session.commit()
 
 
 def remove_monitoring_module(module_code):
@@ -313,3 +320,14 @@ def available_modules():
             available_modules_.append({**module, "module_code": d})
         break
     return available_modules_
+
+
+def extract_keys(test_dict, keys=[]):
+    """
+    FOnction permettant d'extraire de façon récursive les clés d'un dictionnaire
+    """
+    for key, val in test_dict.items():
+        keys.append(key)
+        if isinstance(val, dict):
+            extract_keys(val, keys)
+    return keys

--- a/backend/gn_module_monitoring/conf_schema_toml.py
+++ b/backend/gn_module_monitoring/conf_schema_toml.py
@@ -7,8 +7,21 @@
 from marshmallow import Schema, fields, validates_schema, ValidationError
 
 
+# Permissions associés à chaque objet monitoring
+PERMISSION_LEVEL_DEFAULT = {
+    "module": "MONITORINGS_MODULES",
+    "site": "MONITORINGS_SITES",
+    "sites_group": "MONITORINGS_GRP_SITES",
+    "visit": "MONITORINGS_VISITES",
+    "observation": "MONITORINGS_VISITES",
+    "observation_detail": "MONITORINGS_VISITES",
+}
+
+
 class GnModuleSchemaConf(Schema):
-    pass
+    PERMISSION_LEVEL = fields.Dict(
+        keys=fields.Str(), values=fields.Str(), load_default=PERMISSION_LEVEL_DEFAULT
+    )
 
 
 #     AREA_TYPE = fields.List(fields.String(), missing=["COM", "M1", "M5", "M10"])

--- a/backend/gn_module_monitoring/config/generic/module.json
+++ b/backend/gn_module_monitoring/config/generic/module.json
@@ -1,5 +1,4 @@
 {
-  "cruved": {"C":4, "U":3, "D": 4},
   "id_field_name": "id_module",
   "description_field_name": "module_label",
   "label": "Module",

--- a/backend/gn_module_monitoring/config/generic/observation.json
+++ b/backend/gn_module_monitoring/config/generic/observation.json
@@ -1,5 +1,4 @@
 {
-  "cruved": {"C":1, "U":1, "D": 1},
   "id_field_name": "id_observation",
   "description_field_name": "id_observation",
   "chained": true,

--- a/backend/gn_module_monitoring/config/generic/observation_detail.json
+++ b/backend/gn_module_monitoring/config/generic/observation_detail.json
@@ -1,5 +1,4 @@
 {
-  "cruved": {"C":1, "U":1, "D": 1},
   "id_field_name": "id_observation_detail",
   "description_field_name": "id_observation_detail",
   "chained": true,

--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -1,5 +1,4 @@
 {
-  "cruved": {"C":1, "U":1, "D": 1},
   "chained": true,
   "id_field_name": "id_base_site",
   "description_field_name": "base_site_name",

--- a/backend/gn_module_monitoring/config/generic/sites_group.json
+++ b/backend/gn_module_monitoring/config/generic/sites_group.json
@@ -1,5 +1,4 @@
 {
-    "cruved": {"C":1, "U":1, "D": 1},
     "id_field_name": "id_sites_group",
     "chained": true,
     "description_field_name": "sites_group_name",
@@ -60,6 +59,5 @@
         "attribut_label": "Médias",
         "schema_dot_table": "gn_monitoring.t_sites_groups"
       }
-    } 
+    }
   }
-    

--- a/backend/gn_module_monitoring/config/generic/visit.json
+++ b/backend/gn_module_monitoring/config/generic/visit.json
@@ -1,5 +1,4 @@
 {
-  "cruved": {"C":1, "U":1, "D": 1},
   "id_field_name": "id_base_visit",
   "chained": true,
   "description_field_name": "visit_date_min",

--- a/backend/gn_module_monitoring/config/generic/visit.json
+++ b/backend/gn_module_monitoring/config/generic/visit.json
@@ -82,6 +82,7 @@
       "type_util": "dataset",
       "attribut_label": "Jeu de données",
       "module_code": "__MODULE.MODULE_CODE",
+      "creatable_in_module": "__MODULE.MODULE_CODE.MONITORINGS_VISITES",
       "required": true
     },
     "nb_observations": {

--- a/backend/gn_module_monitoring/config/repositories.py
+++ b/backend/gn_module_monitoring/config/repositories.py
@@ -135,7 +135,6 @@ def get_config(module_code=None, force=False):
 
     config = config_from_files("config", module_code)
     get_config_objects(module_code, config)
-
     # customize config
     if module:
         custom = {}

--- a/backend/gn_module_monitoring/migrations/3ffeea74a9dd_rename_gnm__to_monitorings_.py
+++ b/backend/gn_module_monitoring/migrations/3ffeea74a9dd_rename_gnm__to_monitorings_.py
@@ -1,0 +1,36 @@
+"""Rename GNM_ to MONITORINGS_
+
+Revision ID: 3ffeea74a9dd
+Revises: fc90d31c677f
+Create Date: 2023-10-02 12:00:30.382163
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "3ffeea74a9dd"
+down_revision = "fc90d31c677f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE gn_permissions.t_objects
+               SET code_object = REPLACE(code_object, 'GNM_', 'MONITORINGS_')
+        WHERE code_object like 'GNM_%'
+               """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE gn_permissions.t_objects
+               SET code_object = REPLACE(code_object, 'MONITORINGS_', 'GNM_')
+        WHERE code_object like 'MONITORINGS_%'
+    """
+    )

--- a/backend/gn_module_monitoring/migrations/6a15625a0f4a_delete_object_all.py
+++ b/backend/gn_module_monitoring/migrations/6a15625a0f4a_delete_object_all.py
@@ -1,0 +1,99 @@
+"""Delete object ALL
+
+Revision ID: 6a15625a0f4a
+Revises: c1528c94d350
+Create Date: 2023-10-02 13:53:05.682108
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "6a15625a0f4a"
+down_revision = "c1528c94d350"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Suppression des permissions available de ALL pour les modules monitorings
+    op.execute(
+        """
+        WITH to_del AS (
+            SELECT tp.*
+            FROM gn_permissions.t_permissions_available AS tp
+            JOIN gn_commons.t_modules AS tm
+            ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+            JOIN gn_permissions.t_objects AS o
+            ON o.id_object = tp.id_object AND code_object = 'ALL'
+        )
+        DELETE FROM gn_permissions.t_permissions_available AS tp
+        USING to_del td
+        WHERE  tp.id_module = td.id_module
+        AND tp.id_object = td.id_object
+        AND tp.id_action = td.id_action
+        AND tp."label" = td."label"
+        AND tp.scope_filter = td.scope_filter
+        AND tp.sensitivity_filter = td.sensitivity_filter;
+        """
+    )
+
+    # Suppression des permissions  de ALL pour les modules monitorings
+    op.execute(
+        """
+        WITH to_del AS (
+            SELECT DISTINCT tp.id_permission
+            FROM gn_permissions.t_permissions AS tp
+            JOIN gn_commons.t_modules AS tm
+            ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+            JOIN gn_permissions.t_objects AS o
+            ON o.id_object = tp.id_object AND code_object = 'ALL'
+        )
+        DELETE FROM  gn_permissions.t_permissions AS tp
+        WHERE tp.id_permission IN (SELECT id_permission FROM to_del);
+        """
+    )
+
+
+def downgrade():
+    # Creations des permissions available de ALL pour les modules monitorings
+    #  a partir de GNM_MODULES
+    op.execute(
+        """
+        INSERT INTO gn_permissions.t_permissions_available
+        (id_module, id_object, id_action, "label", scope_filter, sensitivity_filter)
+        SELECT
+            tp.id_module,
+            gn_permissions.get_id_object('ALL') AS id_object,
+            tp.id_action,
+            tp."label",
+            tp.scope_filter,
+            tp.sensitivity_filter
+        FROM gn_permissions.t_permissions_available AS tp
+        JOIN gn_commons.t_modules AS tm
+        ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+        JOIN gn_permissions.t_objects AS o
+        ON o.id_object = tp.id_object AND code_object = 'MONITORINGS_MODULES';
+        """
+    )
+    # Creations des permissions de ALL pour les modules monitorings
+    #  a partir de GNM_MODULES
+    op.execute(
+        """
+        INSERT INTO gn_permissions.t_permissions
+        (id_role, id_action, id_module, id_object, scope_value, sensitivity_filter)
+        SELECT
+            tp.id_role,
+            tp.id_action,
+            tp.id_module,
+            gn_permissions.get_id_object('ALL') AS id_object,
+            tp.scope_value,
+            tp.sensitivity_filter
+        FROM gn_permissions.t_permissions AS tp
+        JOIN gn_commons.t_modules AS tm
+        ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+        JOIN gn_permissions.t_objects AS o
+        ON o.id_object = tp.id_object AND code_object = 'MONITORINGS_MODULES';
+        """
+    )

--- a/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
+++ b/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
@@ -1,0 +1,115 @@
+"""Upgrade existing permissions
+
+Revision ID: c1528c94d350
+Revises: 3ffeea74a9dd
+Create Date: 2023-10-02 12:09:53.695122
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from click.testing import CliRunner
+
+from gn_module_monitoring.command.cmd import process_available_permissions
+from gn_module_monitoring.command.utils import installed_modules
+
+# revision identifiers, used by Alembic.
+revision = "c1528c94d350"
+down_revision = "3ffeea74a9dd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Création des permissions disponibles pour chaque module
+    for module in installed_modules():
+        process_available_permissions(module["module_code"])
+
+    # ########
+    # Mise à jour des permissions existantes vers les sous objets
+    # Création des permission des sous-objets à partir des permissions contenus dans l'objet ALL
+    op.execute(
+        """
+        WITH ap AS (
+            SELECT o.code_object,o.id_object, tpa.id_module
+            FROM gn_permissions.t_permissions_available AS tpa
+            JOIN gn_permissions.t_objects AS o
+            ON o.id_object = tpa.id_object AND NOT code_object = 'ALL'
+            JOIN gn_commons.t_modules AS tm
+            ON tm.id_module = tpa.id_module AND tm."type" = 'monitoring_module'
+        ), ep AS (
+                SELECT id_role, id_action, tp.id_module , tp.id_object, scope_value, sensitivity_filter
+                FROM gn_permissions.t_permissions AS tp
+                JOIN gn_permissions.t_objects AS o
+                ON o.id_object = tp.id_object AND code_object = 'ALL'
+                JOIN gn_commons.t_modules AS tm
+                ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+        ), new_p AS (
+            SELECT DISTINCT ep.id_role, ep.id_action, ep.id_module, ap.id_object, ep.scope_value, ep.sensitivity_filter
+            FROM ep
+            JOIN ap
+            ON ep.id_module = ap.id_module
+            LEFT OUTER JOIN  gn_permissions.t_permissions AS p
+            ON p.id_role = ep.id_role
+            AND  p.id_action = ep.id_action
+            AND  p.id_module = ep.id_module
+            AND  p.id_object = ap.id_object
+            WHERE p.id_permission IS NULL
+        )
+        INSERT INTO gn_permissions.t_permissions
+        (id_role, id_action, id_module, id_object, scope_value, sensitivity_filter)
+        SELECT id_role, id_action, id_module, id_object, scope_value, sensitivity_filter
+        FROM new_p;
+    """
+    )
+
+    #  Suppression des permissions available inutile
+    #  on conserve POUR all
+    #  R : accès au module
+    #  U : modification des paramètres du module
+    #  E : Exporter les données du module
+    op.execute(
+        """
+        WITH to_del AS (
+            SELECT tp.*
+            FROM gn_permissions.t_permissions_available AS tp
+            JOIN gn_commons.t_modules AS tm
+            ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+            JOIN gn_permissions.t_objects AS o
+            ON o.id_object = tp.id_object AND code_object = 'ALL'
+            JOIN gn_permissions.bib_actions AS ba
+            ON tp.id_action = ba.id_action AND NOT ba.code_action  IN ('R', 'E', 'U')
+        )
+        DELETE FROM gn_permissions.t_permissions_available AS tp
+        USING to_del td
+        WHERE  tp.id_module = td.id_module
+        AND tp.id_object = td.id_object
+        AND tp.id_action = td.id_action
+        AND tp."label" = td."label"
+        AND tp.scope_filter = td.scope_filter
+        AND tp.sensitivity_filter = td.sensitivity_filter;
+    """
+    )
+
+    # Suppression des permissions qui ne sont pas dans les permissions available
+    op.execute(
+        """
+        WITH to_del AS (
+            SELECT tp.id_permission
+            FROM gn_permissions.t_permissions AS tp
+            JOIN gn_commons.t_modules AS tm
+            ON tm.id_module = tp.id_module AND tm."type" = 'monitoring_module'
+            LEFT OUTER JOIN gn_permissions.t_permissions_available AS ta
+            ON tp.id_action = ta.id_action
+            AND tp.id_module = ta.id_module
+            AND tp.id_object = ta.id_object
+            WHERE ta.id_module  IS NULL
+        )
+        DELETE FROM  gn_permissions.t_permissions AS tp
+        WHERE tp.id_permission IN (SELECT id_permission FROM to_del);
+    """
+    )
+
+
+def downgrade():
+    pass

--- a/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
+++ b/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
@@ -37,6 +37,7 @@ def upgrade():
             ON o.id_object = tpa.id_object AND NOT code_object = 'ALL'
             JOIN gn_commons.t_modules AS tm
             ON tm.id_module = tpa.id_module AND tm."type" = 'monitoring_module'
+            WHERE NOT (code_object = 'MONITORINGS_MODULES' AND ba.code_action = 'U')
         ), ep AS (
                 SELECT id_role, id_action, tp.id_module , tp.id_object, scope_value, sensitivity_filter
                 FROM gn_permissions.t_permissions AS tp

--- a/backend/gn_module_monitoring/modules/repositories.py
+++ b/backend/gn_module_monitoring/modules/repositories.py
@@ -78,8 +78,6 @@ def get_modules():
     :return:
     """
 
-    modules_out = []
-
     try:
         res = DB.session.query(TMonitoringModules).order_by(TMonitoringModules.module_label).all()
 
@@ -88,9 +86,6 @@ def get_modules():
     except Exception as e:
         raise GeoNatureError("MONITORINGS - get_modules : {}".format(str(e)))
         # en cas d'erreur on revoie []
-        pass
-
-    return modules_out
 
 
 def get_source_by_code(value):

--- a/backend/gn_module_monitoring/monitoring/definitions.py
+++ b/backend/gn_module_monitoring/monitoring/definitions.py
@@ -37,22 +37,4 @@ MonitoringObjects_dict = {
     "sites_group": MonitoringObjectGeom,
 }
 
-MonitoringPermissions_dict = {
-    "site": "GNM_SITES",
-    "sites_group": "GNM_GRP_SITES",
-    "visite": "GNM_VISITES",
-    "observation": "GNM_OBSERVATIONS",
-    "module": "GNM_MODULES",
-}
-
-MonitoringPermissionObjectLabel_dict = {
-    "ALL": "objets (sites, visites, observations, etc...)",
-    "GNM_SITES": "sites",
-    "GNM_OBSERVATIONS": "observations",
-    "GNM_VISITES": "visites",
-    "GNM_GRP_SITES": "groupes de sites",
-    "GNM_MODULES": "modules",
-}
-
-
 monitoring_definitions.set(MonitoringObjects_dict, MonitoringModels_dict)

--- a/backend/gn_module_monitoring/routes/modules.py
+++ b/backend/gn_module_monitoring/routes/modules.py
@@ -19,7 +19,7 @@ from ..modules.repositories import (
 )
 
 
-@blueprint.route("/module/<value>", methods=["GET"])
+@blueprint.route("/module/<int:value>", methods=["GET"])
 @check_cruved_scope("R", module_code=MODULE_CODE)
 @json_resp
 def get_module_api(value):
@@ -37,7 +37,9 @@ def get_module_api(value):
     module_out = []
     if module:
         module_out = module.as_dict(depth=depth)
-        module_out["cruved"] = get_scopes_by_action(module_code=module.module_code)
+        module_out["cruved"] = get_scopes_by_action(
+            module_code=module.module_code, object_code="MONITORINGS_MODULES"
+        )
 
     return module_out
 
@@ -56,7 +58,9 @@ def get_modules_api():
     modules = get_modules()
     for module in modules:
         module_out = module.as_dict(depth=depth)
-        module_out["cruved"] = get_scopes_by_action(module_code=module.module_code)
+        module_out["cruved"] = get_scopes_by_action(
+            module_code=module.module_code, object_code="MONITORINGS_MODULES"
+        )
 
         modules_out.append(module_out)
 

--- a/backend/gn_module_monitoring/routes/monitoring.py
+++ b/backend/gn_module_monitoring/routes/monitoring.py
@@ -27,7 +27,7 @@ from geonature.utils.env import DB, ROOT_DIR
 import geonature.utils.filemanager as fm
 
 from gn_module_monitoring import MODULE_CODE
-from ..monitoring.definitions import monitoring_definitions, MonitoringPermissions_dict
+from ..monitoring.definitions import monitoring_definitions
 from ..modules.repositories import get_module
 from ..utils.utils import to_int
 from ..config.repositories import get_config
@@ -46,8 +46,10 @@ def set_current_module(endpoint, values):
 
     # recherche de l'object de permission courrant
     object_type = values.get("object_type")
+
     if object_type:
-        requested_permission_object_code = MonitoringPermissions_dict.get(object_type)
+        permission_level = current_app.config["MONITORINGS"].get("PERMISSION_LEVEL", {})
+        requested_permission_object_code = permission_level.get(object_type)
 
         if requested_permission_object_code is None:
             # error ?

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,9 @@ CHANGELOG
 0.7.1 (unreleased)
 ------------------
 
+**🚀 Nouveautés**
+* La gestion des permissions est définie pour chaque objet (module, site, visite) et l'objet ALL n'est plus pris en compte (#249).
+
 **🐛 Corrections**
 
 * export avec un filtre par jeux de données (#241)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,11 +5,12 @@ CHANGELOG
 ------------------
 
 **🚀 Nouveautés**
-* La gestion des permissions est définie pour chaque objet (module, site, visite) et l'objet ALL n'est plus pris en compte (#249).
+* La gestion des permissions est définie pour chaque objet (module, site, visite) et l'objet ALL n'est plus pris en compte (#249). De fait les paramètres cruved des fichiers de configuration ainsi que permission object de `module.json` sont obsolètes.
 
 **🐛 Corrections**
 
 * export avec un filtre par jeux de données (#241)
+
 
 0.7.0 (2023-08-23)
 ------------------

--- a/docs/sous_module.md
+++ b/docs/sous_module.md
@@ -16,7 +16,6 @@ title: 'Création d''un sous-module'
     - [La variable `change`](#la-variable-change)
 - [Nomenclature](#nomenclature)
 - [Configuration de la carte](#configuration-de-la-carte)
-- [Gestion des droits](#gestion-des-droits)
 - [Exports](#exports)
   - [PDF](#pdf)
   - [CSV](#csv)
@@ -82,15 +81,6 @@ Dans le fichier `config.json` :
     }
 ```
 
-* `permission_objects` : liste des objets permissions à associer au
-    module. Elle peut contenir les valeurs suivantes
-    `["GNM_MODULES", "GNM_GRP_SITES", "GNM_SITES", "GNM_VISITES", "GNM_OBSERVATIONS"]`
-
-    * Par exemple, pour les sites, par défaut l'API va vérifier les droits pour l'objet de permission `ALL` associé au sous-module.
-
-    * Si des permissions sont définies pour ce module et l'object `GNM_SITES`, l'API des sites ira vérifier les droits en rapport avec `GNM_SITES`.
-
-
 # Configuration des objets
 
 Dans le fichier `module.json`, deux variables doivent obligatoirement
@@ -99,9 +89,6 @@ Dans le fichier `module.json`, deux variables doivent obligatoirement
 * `module_code`: un nom cours, en minuscule et simple, par exemple
     `cheveches` ou `oedic` pour les protocoles chevêches ou oedicnèmes.
 * `module_desc`: une description succinte du module.
-
-Une variable optionnelle permet de configurer les objets faisant
-l'objet de permission :
 
 Dans le cas général (`module.json`, `site.json`, `visit.json`,
 `observation.json`) on peut redéfinir au besoin certaines variables.
@@ -616,33 +603,6 @@ Pour cela éditez le fichier de configuration associé (`module.json`,
 NB : pour ajouter une popup sur la liste des sites, éditez le fichier
 `module.json`, pour la liste des visites le fichier `site.json` etc....
 
-# Gestion des droits
-
-Actuellement le CRUVED est implémenté de manière partielle au niveau du
-module MONITORING. Il n'y a actuellement pas de vérification des
-portées, les droits s'appliquent sur toutes les données.
-
-Si on définit un CRUVED sur un sous-module, alors cela surcouche pour ce
-sous-module le CRUVED défini au niveau de tout le module Monitoring.
-
-Par défaut les valeurs définies du CRUVED sont :
-
-* `site_group.json` : ` "cruved": {"C":1, "U":1,"D": 1},`
-* `site.json` : ` "cruved": {"C":1, "U":1, "D": 1},`
-* `visit.json` : ` "cruved": {"C":1, "U":1, "D": 1},`
-* `observation.json` : ` "cruved": {"C":1, "U":1, "D": 1},`
-* `observation_detail.json` : ` "cruved": {"C":1, "U":1, "D": 1},`
-
-Pour surcoucher les permissions, il faut rajouter la variable cruved
-dans les fichiers de configuration du module (`site_group.json`,
-`site.json`, ....)
-
-```json
-"cruved": {"C": 3, "U": 3, "D": 3},
-```
-
-* Pour pouvoir modifier les paramètres d'un module, il faut que le
-    CRUVED de l'utilisateur ait un U=3 pour ce sous-module.
 
 # Exports
 

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.html
@@ -5,8 +5,7 @@
     placeholder="Entrer une valeur pour filtrer les colonnes"
     (keyup)="updateFilter($event)"
   /> -->
-
-  <ngx-datatable
+   <ngx-datatable
     *ngIf="rows"
     #table
     class="material striped custom-dt"
@@ -35,14 +34,15 @@
         <a
           class="nav-link link cell-link"
           (click)="child0.navigateToDetail(row.id)"
+          *ngIf="child0 && currentUser.moduleCruved[child0.objectType].R >= 1"
           matTooltip="Consulter {{child0.template.label_art_def}}"
         >
           <i class="fa fa-eye" aria-hidden="true"></i>
         </a>
         <a
-          *ngIf="child0.child0()"
           class="nav-link link cell-link"
           (click)="child0.navigateToAddChildren(null, row.id)"
+          *ngIf="child0.child0() && currentUser.moduleCruved[child0.child0().objectType].C >= 1"
           matTooltip="Ajouter {{child0.child0().labelArtUndef(true)}}"
         >
           <i class="fa fa-plus" aria-hidden="true"></i>
@@ -63,9 +63,9 @@
     <div class="header-sort-span" (click)="sortFn()">
       {{column.definition}}
       <i class="material-icons icon-sort" [innerText]="sortDir ? (sortDir === 'asc' ? 'arrow_upward' : 'arrow_downward') : ''"></i>
-      <i 
+      <i
         *ngIf="child0.template.fieldDefinitions[column.prop]"
-        class="material-icons icon-sort" 
+        class="material-icons icon-sort"
         [matTooltip]="tooltip(column)"
         matTooltipPosition="above"
         >help</i>

--- a/frontend/app/components/monitoring-form/monitoring-form.component.html
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.html
@@ -115,7 +115,7 @@
           <span *ngIf="!bChainInput || obj.id">Valider</span>
         </button>
 
-        <button 
+        <button
           mat-raised-button
           color="warn"
           class="float-left" (click)="onCancelEdit()">
@@ -126,7 +126,7 @@
           color="warn"
           class="float-left"
           (click)="bDeleteModal = true"
-          *ngIf="obj.id && currentUser.moduleCruved[obj.objectType].D >= obj.cruved('D')"
+          *ngIf="obj.id && currentUser.moduleCruved[obj.objectType].D >= 1"
         >
           Supprimer
         </button>

--- a/frontend/app/components/monitoring-lists/monitoring-lists.component.html
+++ b/frontend/app/components/monitoring-lists/monitoring-lists.component.html
@@ -1,11 +1,15 @@
+
 <div class="cadre" *ngIf="children0Array && children0Array.length">
 
+
   <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
-    <mat-tab
+    <span
       *ngFor="let child0 of children0Array"
+      >
+    <mat-tab
+       *ngIf="obj.moduleCode && currentUser.moduleCruved[child0.objectType].R >= 1"
       (click)="changeActiveTab(child0.objectType)"
       label="{{child0.template['label_list']}} {{displayNumber(child0.objectType)}}"  >
-
       <div let childrenType="child0.objectType" class="list-children">
         <div
           class="btn-height"
@@ -18,18 +22,16 @@
               class="ml-2 mb-2"
               (click)="child0.config['display_filter'] = !child0.config['display_filter']"
               matTooltip="{{child0.config['display_filter'] ? 'Cacher' : 'Afficher'}} les filtres"
-              *ngIf="obj.moduleCode && currentUser.moduleCruved[child0.objectType].R >= child0.cruved('R')"
               >
               <mat-icon>filter_alt</mat-icon>
             </button
             >
-
             <button
               mat-raised-button
               color="primary"
               class="btn btn-success float-right"
               (click)="obj.navigateToAddChildren(child0.objectType)"
-              *ngIf="obj.moduleCode && currentUser.moduleCruved[child0.objectType].C >= child0.cruved('C')"
+              *ngIf="obj.moduleCode && currentUser.moduleCruved[child0.objectType].C >= 1"
               ><i class="fa fa-plus" aria-hidden="true"></i> Ajouter
               {{ (child0.template["label_art_undef_new"] || "") }}</button
             >
@@ -52,6 +54,7 @@
         </div>
       </div>
     </mat-tab>
+    </span>
   </mat-tab-group>
 
 

--- a/frontend/app/components/monitoring-properties/monitoring-properties.component.html
+++ b/frontend/app/components/monitoring-properties/monitoring-properties.component.html
@@ -23,7 +23,7 @@
         </table>
       </div>
     </mat-tab>
-    <mat-tab 
+    <mat-tab
       *ngIf="obj.properties['medias'] && obj.properties['medias'].length"
       label="Médias ({{(obj.properties['medias'] && obj.properties['medias'].length) || 0}})"
     >
@@ -51,7 +51,7 @@
       </ng-container>
     </mat-tab>
   </mat-tab-group>
-  
+
   <div class="tab-content" id="nav-tabContent" [ngStyle]="{'background-color': obj.template['color']}" >
     <div
       class="tab-pane fade active show"
@@ -70,7 +70,6 @@
     >
     </div>
 
-
     <button
       mat-stroked-button
       color="primary"
@@ -78,24 +77,27 @@
       (click)="onEditClick()"
       *ngIf="
         !bEdit &&
-        currentUser?.moduleCruved[obj.objectType].U >= obj.cruved('U')
+        currentUser?.moduleCruved[obj.objectType].U >= 1
       "
     >
       Éditer {{ (obj.template['label_art_def'] || "") }}
     </button>
 
     <!-- export pdf -->
-    <button
-      mat-stroked-button
-      color="primary"
-      *ngFor="let exportPdfConfig of (obj.template['export_pdf'] || [])"
-      (click)="processExportPdf(exportPdfConfig)"
-      type="button"
-      class="mr-2" >
-      <i class="fa fa-file-pdf-o"></i>&nbsp;
-      {{exportPdfConfig.label}}
-    </button>
+    <span  *ngFor="let exportPdfConfig of (obj.template['export_pdf'] || [])">
+      <button
+        mat-stroked-button
+        color="primary"
 
+        (click)="processExportPdf(exportPdfConfig)"
+        type="button"
+        class="mr-2"
+        *ngIf="currentUser?.moduleCruved[obj.objectType].E >= 1"
+      >
+        <i class="fa fa-file-pdf-o"></i>&nbsp;
+        {{exportPdfConfig.label}}
+      </button>
+    </span>
     <!-- Mise à jour de la synthèse (Admin) -->
     <button
     mat-stroked-button
@@ -105,7 +107,7 @@
     *ngIf="
       !bEdit &&
       obj.objectType === 'module' &&
-      currentUser?.moduleCruved.module.U >= 3 &&
+      currentUser?.moduleCruved.module.U >= 1 &&
       obj.properties['b_synthese']
     "
     matTooltip="Attention, cette opération peux prendre du temps"
@@ -123,7 +125,7 @@
 
   <button
     mat-stroked-button
-    *ngIf="obj.template['export_csv']"
+    *ngIf="obj.template['export_csv'] && currentUser?.moduleCruved[obj.objectType].E >= 1"
     class="mr-2"
     color="primary"
     (click)="openModalExportCsv($event, modalExportCsv)">

--- a/frontend/app/services/config.service.ts
+++ b/frontend/app/services/config.service.ts
@@ -71,24 +71,15 @@ export class ConfigService {
   }
 
   moduleCruved(module_code) {
-    const permObjectDict = {
-      site: 'GNM_SITES',
-      sites_group: 'GNM_GRP_SITES',
-      visit: 'GNM_VISITES',
-      observation: 'GNM_OBSERVATIONS',
-      module: 'GNM_MODULES',
-    };
-
+    const permObjectDict = this.appConfig.MONITORINGS.PERMISSION_LEVEL;
     const module = this._moduleService.getModule(module_code);
 
     const moduleCruved = {};
-
     for (const [objectCode, permObjectCode] of Object.entries(permObjectDict)) {
       moduleCruved[objectCode] =
         module.objects.find((o) => o.code_object == permObjectDict[objectCode])?.cruved ||
         module.cruved;
     }
-
     return moduleCruved;
   }
 


### PR DESCRIPTION
cf #249 
- [x] prefixer les modules par MONITORINGS plutôt que GNM
- [x] Remplacer l'objet ALL par MODULES
- [x] Modifier commande `update_module_available_permissions` : utiliser l'objet tree pour définir les permissions disponibles 
- [x] Créer migration permettant de limiter les permissions de l'objet ALL à RUE
- [x]  Création d'une commande permettant migration des permissions actuellement sur l'objet ALL dans les sous objets monitorings après avoir lancé `update_module_available_permissions` 

- [x] front : ne pas regarder les droits de l'objet ALL dans les grps sites, sites, visites....

- [x] config : supprimer cruved
- [x] config: supprimer permission_objects