### PR TITLE
Remove duplicate visits dataset

### DIFF
--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -83,9 +83,6 @@ class TMonitoringObservations(TObservations):
     )
 
 
-TBaseVisits.dataset = DB.relationship(TDatasets)
-
-
 @serializable
 class TMonitoringVisits(TBaseVisits):
     __tablename__ = "t_visit_complements"


### PR DESCRIPTION
Suppression du message ` SAWarning: Property TBaseVisits.dataset on mapped class TBaseVisits->t_base_visits being replaced with new property TBaseVisits.dataset; the old property will be discarded`

cf https://github.com/PnX-SI/gn_module_monitoring/issues/225

A intégrer en parallèle de: https://github.com/PnX-SI/GeoNature/pull/2773