### PR TITLE
Missing JOIN to bib_actions table in revision 

### DIFF
--- a/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
+++ b/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
@@ -37,6 +37,7 @@ def upgrade():
             ON o.id_object = tpa.id_object AND NOT code_object = 'ALL'
             JOIN gn_commons.t_modules AS tm
             ON tm.id_module = tpa.id_module AND tm."type" = 'monitoring_module'
+            JOIN gn_permissions.bib_actions as ba ON ba.id_action = tpa.id_action
             WHERE NOT (code_object = 'MONITORINGS_MODULES' AND ba.code_action = 'U')
         ), ep AS (
                 SELECT id_role, id_action, tp.id_module , tp.id_object, scope_value, sensitivity_filter


### PR DESCRIPTION
Il manquait une jointure dans la révision Alembic `c1528c94d350_upgrade_existing_permissions.py`. 