### PR TITLE
[DRAFT][Permissions]Ajout des filtres sur la portée des données

### DIFF
--- a/backend/gn_module_monitoring/monitoring/base.py
+++ b/backend/gn_module_monitoring/monitoring/base.py
@@ -137,32 +137,6 @@ class MonitoringObjectBase:
 
     def config_schema(self, type_schema="all"):
         return repositories_config_schema(self._module_code, self._object_type, type_schema)
-        pass
-
-    # def base_type_object(self):
-    #     """
-    #         renvoie:
-    #         - le type d'objet dont herite l'objet
-    #         - le type d'objet sinon
-
-    #     """
-    #     return self.config_param('inherit_type') or self._object_type
-
-    # def is_similar_to_parent(self):
-    #     '''
-    #         on teste si le type de parent est similaire au type de l'object (ou au type herite de l'object)
-    #     '''
-    #     base_object_type = self.base_type_object()
-    #     parent_type = self.config_param('parent_type')
-
-    #     if not parent_type:
-    #         return False
-
-    #     base_parent_type = (
-    #         repositories_config_param(self._module_code, parent_type, 'inherit_type') or parent_type
-    #     )
-
-    #     return base_object_type == base_parent_type
 
     def id_parent_fied_name(self):
         return self.parent_config_param("id_field_name")


### PR DESCRIPTION
Pour faire suite à l'issue [249](https://github.com/PnX-SI/gn_module_monitoring/issues/249) et refléter le comportement que l'on a côté Occtax, il serait intéressant d'implémenter un filtre sur la portée des données pour les différents objets de monitoring (mes données, données de mon organisme, toutes les données).

Pour les besoins du CREA, je vais tenter de l'implémenter dans cette PR, à la manière d'occtax pour avoir le comportement le plus similaire possible.

Je pense que les principales difficultés seront liées à : 
 - la généricité du module (on manipule différents types d'objets au sein d'une même route API)
 - l'héritage:
   - Si j'ai le droit de voir mon site, mais qu'il existe des visites qui n'ont pas été créées par moi, ai je droit de les voir ?
   - Si j'ai le droit de voir les visites, mais pas les sites, que se passe t'il ? Est ce que je peux quand même voir les sites où mes visites sont présentes ou rien du tout ?

Preneur de toute aide ou remarque sur le sujet.