### PR TITLE
fix: use javascript number type

### DIFF
--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -27,7 +27,10 @@
     "nb_visits"
   ],
   "sorts": [
-    {"prop": "last_visit", "dir": "desc"}
+    {
+      "prop": "last_visit",
+      "dir": "desc"
+    }
   ],
   "generic": {
     "id_base_site": {
@@ -54,7 +57,6 @@
       "type_widget": "textarea",
       "attribut_label": "Description"
     },
-
     "id_sites_group": {
       "type_widget": "datalist",
       "attribut_label": "Groupe de sites",
@@ -115,12 +117,12 @@
       "schema_dot_table": "gn_monitoring.t_base_sites"
     },
     "altitude_min": {
-      "type_widget": "integer",
+      "type_widget": "number",
       "attribut_label": "Altitude (min)"
-      },
-      "altitude_max": {
-      "type_widget": "integer",
+    },
+    "altitude_max": {
+      "type_widget": "number",
       "attribut_label": "Altitude (max)"
-      }
+    }
   }
 }

--- a/backend/gn_module_monitoring/config/repositories.py
+++ b/backend/gn_module_monitoring/config/repositories.py
@@ -213,7 +213,7 @@ def config_schema(module_code, object_type, type_schema="all"):
         {
             "attribut_name": "id_base_site",
             "Label": "Id du site",
-            "type_widget": "integer",
+            "type_widget": "text",
             "required": "true",
         }
 


### PR DESCRIPTION
L'altitude min et max ne s'affiche pas dans le frontend lorsque le type integer est utilisé, seul le type number semble fonctionner pour l'affichage de nombres côté frontend.