### PR TITLE
chore: add venv to git ignore and change submodules URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tmp/
 npm-debug.log*
 yarn-error.log*
 .ng_pkg_build/
+
+# Python
+venv

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dependencies/GeoNature"]
 	path = dependencies/GeoNature
-	url = git@github.com:PnX-SI/GeoNature.git
+	url = https://github.com/PnX-SI/GeoNature.git
     branch = develop


### PR DESCRIPTION
- Adding venv to gitignore for local testing purposes, we should also add common python files to be ignored (.pyc, egg, ...).
- Converting geonature submodule URL to https to be more accessible for people not having SSH keys properly configured