### PR TITLE
Feat/multiple geom type

### DIFF
--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -6,7 +6,7 @@
   "genre": "M",
   "geom_field_name": "geom",
   "uuid_field_name": "uuid_base_site",
-  "geometry_type": "Point",
+  "geometry_type": ["Point", "LineString", "Polygon"],
   "display_properties": [
     "base_site_name",
     "base_site_code",

--- a/frontend/app/components/draw-form/draw-form.component.ts
+++ b/frontend/app/components/draw-form/draw-form.component.ts
@@ -51,35 +51,33 @@ export class DrawFormComponent implements OnInit {
       this.displayed = false;
       return;
     }
-
     this.displayed = true;
-    switch (this.geometryType) {
-      case 'Point': {
-        this.leafletDrawOptions.draw.polygon = false;
-        this.leafletDrawOptions.draw.marker = {
-          icon: new CustomMarkerIcon(),
-        };
-        break;
-      }
-      case 'Polygon': {
-        this.leafletDrawOptions.draw.marker = false;
-        this.leafletDrawOptions.draw.polygon = {
-          allowIntersection: false, // Restricts shapes to simple polygons
-          drawError: {
-            color: '#e1e100', // Color the shape will turn when intersects
-            message: 'Intersection forbidden !', // Message that will show when intersect
-          },
-        };
-        break;
-      }
-      case 'LineString': {
-        this.leafletDrawOptions.draw.polyline = true;
-        break;
-      }
-      default: {
-        this.leafletDrawOptions.draw.marker = true;
-        break;
-      }
+    if (this.geometryType.includes('Point')) {
+      this.leafletDrawOptions.draw.marker = {
+        icon: new CustomMarkerIcon(),
+      };
+    }
+    if (this.geometryType.includes('Polygon')) {
+      this.leafletDrawOptions.draw.polygon = {
+        allowIntersection: false, // Restricts shapes to simple polygons
+        drawError: {
+          color: '#e1e100', // Color the shape will turn when intersects
+          message: 'Intersection forbidden !', // Message that will show when intersect
+        },
+      };
+    }
+    if (this.geometryType.includes('LineString')) {
+      this.leafletDrawOptions.draw.polyline = true;
+    }
+    // default if not specified
+    if (
+      !this.geometryType.includes('LineString') &&
+      !this.geometryType.includes('LineString') &&
+      !this.geometryType.includes('Polygon')
+    ) {
+      this.leafletDrawOptions.draw.marker = {
+        icon: new CustomMarkerIcon(),
+      };
     }
 
     this.leafletDrawOptions = { ...this.leafletDrawOptions };

--- a/frontend/app/components/draw-form/draw-form.component.ts
+++ b/frontend/app/components/draw-form/draw-form.component.ts
@@ -71,7 +71,7 @@ export class DrawFormComponent implements OnInit {
     }
     // default if not specified
     if (
-      !this.geometryType.includes('LineString') &&
+      !this.geometryType.includes('Point') &&
       !this.geometryType.includes('LineString') &&
       !this.geometryType.includes('Polygon')
     ) {


### PR DESCRIPTION
Possibilité de saisir plusieurs type de géométries lors de la création d'un site.
La syntaxe est la suivante : 
`  "geometry_type": "Polygon, Point" `
dans le fichier `site.json`

La surperposition des couches n'est pas bien gérée. Si un polygone recouvre un point on ne peut pas cliquer dessus sur la carte

Voir #136

