### PR TITLE
Fix/delete obs from datatable

### DIFF
--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
@@ -263,12 +263,15 @@ export class MonitoringDatatableComponent implements OnInit {
   }
 
   onDelete(row) {
-    this._commonService.regularToaster('info', this.msgToaster('Suppression'));
-    this._objectService.changeDisplayingDeleteModal(this.bDeleteModal);
-    this._objectService.changeSelectRow({ rowSelected: row, objectType: this.child0.objectType });
-    this._objectService.currentDeleteModal.subscribe(
-      (deletedModal) => (this.bDeleteModal = deletedModal)
-    );
+    this.child0.id = row.id
+    this.child0.delete().subscribe((objData) => {
+      this.bDeleteSpinner = this.bDeleteModal = false;
+      this.child0.deleted = true;
+      this._commonService.regularToaster('info', this.msgToaster('Suppression'));
+      setTimeout(() => {
+        window.location.reload()
+      }, 100);
+    });
   }
 
   alertMessage(row) {

--- a/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
+++ b/frontend/app/components/monitoring-datatable/monitoring-datatable.component.ts
@@ -263,13 +263,13 @@ export class MonitoringDatatableComponent implements OnInit {
   }
 
   onDelete(row) {
-    this.child0.id = row.id
+    this.child0.id = row.id;
     this.child0.delete().subscribe((objData) => {
       this.bDeleteSpinner = this.bDeleteModal = false;
       this.child0.deleted = true;
       this._commonService.regularToaster('info', this.msgToaster('Suppression'));
       setTimeout(() => {
-        window.location.reload()
+        window.location.reload();
       }, 100);
     });
   }


### PR DESCRIPTION
fix: error on delete child from table
    
Use window.location.reload in order to update table (tried to reload this.obj with good data but cache is kept --> cache is deleted only if main obj is deleted not if child is deleted when the url target specific obj.

Issue: https://github.com/PnX-SI/gn_module_monitoring/issues/309
Reviewed-by: andriacap