### PR TITLE
feat: add multi observers to sites

### DIFF
--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -6,12 +6,17 @@
   "genre": "M",
   "geom_field_name": "geom",
   "uuid_field_name": "uuid_base_site",
-  "geometry_type": ["Point", "LineString", "Polygon"],
+  "geometry_type": [
+    "Point",
+    "LineString",
+    "Polygon"
+  ],
   "display_properties": [
     "base_site_name",
     "base_site_code",
     "base_site_description",
     "id_inventor",
+    "observers",
     "first_use_date",
     "last_visit",
     "nb_visits",
@@ -25,10 +30,14 @@
     "last_visit",
     "id_inventor",
     "nb_visits",
+    "observers",
     "types_site"
   ],
   "sorts": [
-    {"prop": "last_visit", "dir": "desc"}
+    {
+      "prop": "last_visit",
+      "dir": "desc"
+    }
   ],
   "generic": {
     "id_base_site": {
@@ -54,9 +63,21 @@
       "type_widget": "observers",
       "attribut_label": "Observateur",
       "type_util": "user",
-      "code_list":"CODE_OBSERVERS_LIST",
+      "code_list": "CODE_OBSERVERS_LIST",
       "required": true,
       "multi_select": false
+    },
+    "observers": {
+      "type_widget": "datalist",
+      "attribut_label": "Observateurs",
+      "api": "users/menu/__MODULE.ID_LIST_OBSERVER",
+      "application": "GeoNature",
+      "keyValue": "id_role",
+      "keyLabel": "nom_complet",
+      "type_util": "user",
+      "multiple": true,
+      "hidden": false,
+      "required": true
     },
     "id_digitiser": {
       "type_widget": "text",
@@ -88,36 +109,37 @@
     "altitude_min": {
       "type_widget": "integer",
       "attribut_label": "Altitude (min)"
-      },
+    },
     "altitude_max": {
       "type_widget": "integer",
       "attribut_label": "Altitude (max)"
-      },
-      "types_site": {
-        "type_widget": "datalist",
-        "attribut_label": "Type(s) de site",
-        "type_util": "types_site",
-        "keyValue": "id_nomenclature_type_site",
-        "keyLabel": "label",
-        "multiple": true,
-        "api" : "__MONITORINGS_PATH/modules/__MODULE.MODULE_CODE/types_sites",
-        "application": "GeoNature",
-        "required": true,
-        "nullDefault":true,
-        "definition": "Permet de n'avoir que les types de site lié au module"
-      },
-      "id_sites_group": {
-        "type_widget": "datalist",
-        "attribut_label": "Groupe de site",
-        "keyValue": "id_sites_group",
-        "keyLabel": "sites_group_name",
-        "multiple": false,
-        "api" : "monitorings/sites_groups",
-        "application": "GeoNature",
-        "data_path":"items",
-        "required": false,
-        "default":null,
-        "nullDefault":true,
-        "definition": "Associer un site à un groupe de site"
-      }  }
+    },
+    "types_site": {
+      "type_widget": "datalist",
+      "attribut_label": "Type(s) de site",
+      "type_util": "types_site",
+      "keyValue": "id_nomenclature_type_site",
+      "keyLabel": "label",
+      "multiple": true,
+      "api": "__MONITORINGS_PATH/modules/__MODULE.MODULE_CODE/types_sites",
+      "application": "GeoNature",
+      "required": true,
+      "nullDefault": true,
+      "definition": "Permet de n'avoir que les types de site lié au module"
+    },
+    "id_sites_group": {
+      "type_widget": "datalist",
+      "attribut_label": "Groupe de site",
+      "keyValue": "id_sites_group",
+      "keyLabel": "sites_group_name",
+      "multiple": false,
+      "api": "monitorings/sites_groups",
+      "application": "GeoNature",
+      "data_path": "items",
+      "required": false,
+      "default": null,
+      "nullDefault": true,
+      "definition": "Associer un site à un groupe de site"
+    }
+  }
 }

--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -15,7 +15,6 @@
     "base_site_name",
     "base_site_code",
     "base_site_description",
-    "id_inventor",
     "observers",
     "first_use_date",
     "last_visit",
@@ -28,7 +27,6 @@
     "base_site_name",
     "base_site_code",
     "last_visit",
-    "id_inventor",
     "nb_visits",
     "observers",
     "types_site"
@@ -58,14 +56,6 @@
     "base_site_description": {
       "type_widget": "textarea",
       "attribut_label": "Description"
-    },
-    "id_inventor": {
-      "type_widget": "observers",
-      "attribut_label": "Observateur",
-      "type_util": "user",
-      "code_list": "CODE_OBSERVERS_LIST",
-      "required": true,
-      "multi_select": false
     },
     "observers": {
       "type_widget": "datalist",

--- a/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
+++ b/backend/gn_module_monitoring/migrations/c1528c94d350_upgrade_existing_permissions.py
@@ -6,14 +6,6 @@ Create Date: 2023-10-02 12:09:53.695122
 
 """
 
-from alembic import op
-import sqlalchemy as sa
-
-from click.testing import CliRunner
-
-from gn_module_monitoring.command.cmd import process_available_permissions
-from gn_module_monitoring.command.utils import installed_modules
-
 # revision identifiers, used by Alembic.
 revision = "c1528c94d350"
 down_revision = "3ffeea74a9dd"

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -89,13 +89,13 @@ class SitesQuery(GnMonitoringGenericFilter):
         elif scope in (1, 2):
             ors = [
                 Models.TMonitoringSites.id_digitiser == user.id_role,
-                Models.TMonitoringSites.id_inventor == user.id_role,
+                Models.TMonitoringSites.observers.any(id_role=user.id_role),
             ]
             # if organism is None => do not filter on id_organism even if level = 2
             if scope == 2 and user.id_organisme is not None:
                 ors += [
-                    Models.TMonitoringSites.inventor.has(id_organisme=user.id_organisme),
                     Models.TMonitoringSites.digitiser.has(id_organisme=user.id_organisme),
+                    Models.TMonitoringSites.observers.any(id_organisme=user.id_organisme),
                 ]
             query = query.where(or_(*ors))
         return query

--- a/backend/gn_module_monitoring/monitoring/schemas.py
+++ b/backend/gn_module_monitoring/monitoring/schemas.py
@@ -134,8 +134,6 @@ class MonitoringSitesSchema(MA.SQLAlchemyAutoSchema):
     pk = fields.Method("set_pk", dump_only=True)
     types_site = MA.Nested(BibTypeSiteSchema, many=True)
     id_sites_group = fields.Method("get_id_sites_group")
-    id_inventor = fields.Method("get_id_inventor")
-    inventor = fields.Method("get_inventor_name")
     observers = MA.Pluck(ObserverSchema, "id_role", many=True)
     medias = MA.Nested(MediaSchema, many=True)
 
@@ -148,13 +146,6 @@ class MonitoringSitesSchema(MA.SQLAlchemyAutoSchema):
 
     def get_id_sites_group(self, obj):
         return obj.id_sites_group
-
-    def get_id_inventor(self, obj):
-        return obj.id_inventor
-
-    def get_inventor_name(self, obj):
-        if obj.inventor:
-            return [obj.inventor.nom_complet]
 
 
 class MonitoringVisitsSchema(MA.SQLAlchemyAutoSchema):

--- a/backend/gn_module_monitoring/monitoring/schemas.py
+++ b/backend/gn_module_monitoring/monitoring/schemas.py
@@ -136,6 +136,7 @@ class MonitoringSitesSchema(MA.SQLAlchemyAutoSchema):
     id_sites_group = fields.Method("get_id_sites_group")
     id_inventor = fields.Method("get_id_inventor")
     inventor = fields.Method("get_inventor_name")
+    observers = MA.Pluck(ObserverSchema, "id_role", many=True)
     medias = MA.Nested(MediaSchema, many=True)
 
     def serialize_geojson(self, obj):

--- a/backend/gn_module_monitoring/tests/fixtures/site.py
+++ b/backend/gn_module_monitoring/tests/fixtures/site.py
@@ -17,7 +17,6 @@ def sites(users, types_site, site_group_with_sites):
     sites = {}
     for i, key in enumerate(types_site.keys()):
         sites[key] = TMonitoringSites(
-            id_inventor=user.id_role,
             id_digitiser=user.id_role,
             base_site_name=f"Site{i}",
             base_site_description=f"Description{i}",
@@ -29,7 +28,6 @@ def sites(users, types_site, site_group_with_sites):
 
     # Add a special site that has no type
     sites["no-type"] = TMonitoringSites(
-        id_inventor=user.id_role,
         id_digitiser=user.id_role,
         base_site_name="no-type",
         base_site_description="Description-no-type",
@@ -57,7 +55,6 @@ def site_to_post_with_types(users, types_site, site_group_without_sites):
         list_nomenclature_id.append(type["id_nomenclature_type_site"])
 
     site_to_post_with_types = TMonitoringSites(
-        id_inventor=user.id_role,
         id_digitiser=user.id_role,
         base_site_name="New Site",
         base_site_description="New Description",

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -165,12 +165,8 @@ def filter_according_to_column_type_for_site(query, params):
             .join(BibTypeSite.nomenclature)
             .where(TNomenclatures.label_fr.ilike(f"%{params_types_site}%"))
         )
-    elif "id_inventor" in params:
-        params_inventor = params.pop("id_inventor")
-        query = query.join(
-            User,
-            User.id_role == TMonitoringSites.id_inventor,
-        ).where(User.nom_complet.ilike(f"%{params_inventor}%"))
+    # TODO: filter by observers
+
     if len(params) != 0:
         query = filter_params(TMonitoringSites, query=query, params=params)
 
@@ -183,11 +179,9 @@ def sort_according_to_column_type_for_site(query, sort_label, sort_dir):
             query = query.order_by(TNomenclatures.label_fr.asc())
         else:
             query = query.order_by(TNomenclatures.label_fr.desc())
-    elif sort_label == "id_inventor":
-        if sort_dir == "asc":
-            query = query.order_by(User.nom_complet.asc())
-        else:
-            query = query.order_by(User.nom_complet.desc())
+
+    # TODO: sort by observers
+
     else:
         query = sort(TMonitoringSites, query=query, sort=sort_label, sort_dir=sort_dir)
     return query

--- a/contrib/sites_group_aside/site.json
+++ b/contrib/sites_group_aside/site.json
@@ -4,6 +4,7 @@
     "base_site_code",
     "id_nomenclature_type_site",
     "id_inventor",
+    "observers",
     "id_sites_group",
     "first_use_date",
     "last_visit",
@@ -21,7 +22,11 @@
       "api": "nomenclatures/nomenclature/TYPE_SITE",
       "application": "GeoNature",
       "filters": {
-        "cd_nomenclature": ["1", "2", "3"]
+        "cd_nomenclature": [
+          "1",
+          "2",
+          "3"
+        ]
       },
       "default": {
         "cd_nomenclature": "1"

--- a/contrib/sites_group_aside/site.json
+++ b/contrib/sites_group_aside/site.json
@@ -3,7 +3,6 @@
     "base_site_name",
     "base_site_code",
     "id_nomenclature_type_site",
-    "id_inventor",
     "observers",
     "id_sites_group",
     "first_use_date",

--- a/contrib/test/site.json
+++ b/contrib/test/site.json
@@ -6,14 +6,15 @@
     "id_nomenclature_type_site",
     "cd_hab",
     "id_inventor",
+    "observers",
     "first_use_date",
     "last_visit",
     "nb_visits"
   ],
   "export_pdf": [
     {
-        "template": "fiche_site.html",
-        "label": "Export PDF"
+      "template": "fiche_site.html",
+      "label": "Export PDF"
     }
   ],
   "map_label_field_name": "base_site_name",
@@ -24,7 +25,11 @@
     },
     "id_nomenclature_type_site": {
       "filters": {
-        "cd_nomenclature": ["1", "2", "3"]
+        "cd_nomenclature": [
+          "1",
+          "2",
+          "3"
+        ]
       },
       "default": {
         "cd_nomenclature": "1"
@@ -48,8 +53,8 @@
       "keyLabel": "search_name",
       "type_util": "habitat",
       "params": {
-          "cd_typo": 7,
-          "search_name": ""
+        "cd_typo": 7,
+        "search_name": ""
       }
     }
   }

--- a/contrib/test/site.json
+++ b/contrib/test/site.json
@@ -5,7 +5,6 @@
     "base_site_description",
     "id_nomenclature_type_site",
     "cd_hab",
-    "id_inventor",
     "observers",
     "first_use_date",
     "last_visit",

--- a/frontend/app/components/monitoring-form-g/monitoring-form.component-g.ts
+++ b/frontend/app/components/monitoring-form-g/monitoring-form.component-g.ts
@@ -98,7 +98,7 @@ export class MonitoringFormComponentG implements OnInit {
     private _formService: FormService,
     private _router: Router,
     private _geojsonService: GeoJSONService
-  ) {}
+  ) { }
 
   ngOnInit() {
     if (!this.objFormStatic) {
@@ -196,12 +196,12 @@ export class MonitoringFormComponentG implements OnInit {
 
           this.obj.config
             ? (this.objFormsDefinition[key] = this._dynformService
-                .formDefinitionsdictToArray(this.obj[configType], this.meta)
-                .filter((formDef) => formDef.type_widget)
-                .sort((a, b) => {
-                  // medias à la fin
-                  return a.attribut_name === 'medias' ? +1 : b.attribut_name === 'medias' ? -1 : 0;
-                }))
+              .formDefinitionsdictToArray(this.obj[configType], this.meta)
+              .filter((formDef) => formDef.type_widget)
+              .sort((a, b) => {
+                // medias à la fin
+                return a.attribut_name === 'medias' ? +1 : b.attribut_name === 'medias' ? -1 : 0;
+              }))
             : null;
         });
 
@@ -404,7 +404,7 @@ export class MonitoringFormComponentG implements OnInit {
 
   /** Pour donner des valeurs par defaut si la valeur n'est pas définie
    * id_digitiser => current_user.id_role
-   * id_inventor => current_user.id_role
+   * observers => [current_user.id_role]
    * date => today
    */
   setDefaultFormValue() {
@@ -412,7 +412,7 @@ export class MonitoringFormComponentG implements OnInit {
     const date = new Date();
     const defaultValue = {
       id_digitiser: value['id_digitiser'] || this.currentUser.id_role,
-      id_inventor: value['id_inventor'] || this.currentUser.id_role,
+      observers: value['observers'] || [this.currentUser.id_role],
       first_use_date: value['first_use_date'] || {
         year: date.getUTCFullYear(),
         month: date.getUTCMonth() + 1,

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -86,7 +86,7 @@ export class MonitoringFormComponent implements OnInit {
     private _formService: FormService,
     private _router: Router,
     private _geojsonService: GeoJSONService
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.initPermission();
@@ -299,7 +299,7 @@ export class MonitoringFormComponent implements OnInit {
 
   /** Pour donner des valeurs par defaut si la valeur n'est pas définie
    * id_digitiser => current_user.id_role
-   * id_inventor => current_user.id_role
+   * observers => [current_user.id_role]
    * date => today
    */
   setDefaultFormValue() {
@@ -307,7 +307,7 @@ export class MonitoringFormComponent implements OnInit {
     const date = new Date();
     const defaultValue = {
       id_digitiser: value['id_digitiser'] || this.currentUser.id_role,
-      id_inventor: value['id_inventor'] || this.currentUser.id_role,
+      observers: value['observers'] || [this.currentUser.id_role],
       first_use_date: value['first_use_date'] || {
         year: date.getUTCFullYear(),
         month: date.getUTCMonth() + 1,

--- a/frontend/app/components/monitoring-sites/monitoring-sites.component.ts
+++ b/frontend/app/components/monitoring-sites/monitoring-sites.component.ts
@@ -129,8 +129,8 @@ export class MonitoringSitesComponent extends MonitoringGeomComponent implements
             tap((data) => {
               data.sitesGroup.is_geom_from_child
                 ? this._geojsonService.getSitesGroupsChildGeometries(this.onEachFeatureSite(), {
-                    id_sites_group: data.sitesGroup.id_sites_group,
-                  })
+                  id_sites_group: data.sitesGroup.id_sites_group,
+                })
                 : this._geojsonService.setGeomSiteGroupFromExistingObject(data.sitesGroup.geometry);
             }),
             mergeMap((data) => {
@@ -196,8 +196,7 @@ export class MonitoringSitesComponent extends MonitoringGeomComponent implements
       .subscribe((data: IPaginated<ISite>) => {
         let siteList = this._siteService.formatLabelTypesSite(data.items);
         this.rows = siteList;
-        const siteListResolvedProp = this._siteService.formatLabelObservers(siteList);
-        this.siteResolvedProperties = siteListResolvedProp;
+        this.siteResolvedProperties = siteList;
         this.dataTableObj.site.rows = this.rows;
         this.dataTableObj.site.page.count = data.count;
         this.dataTableObj.site.page.limit = data.limit;
@@ -279,9 +278,8 @@ export class MonitoringSitesComponent extends MonitoringGeomComponent implements
       objTemp[objType].columns = data[dataType].objConfig.dataTable.colNameObj;
       let siteList = this._siteService.formatLabelTypesSite(data[dataType].items);
       this.rows = siteList;
-      const siteListResolvedProp = this._siteService.formatLabelObservers(siteList);
-      objTemp[objType].rows = siteListResolvedProp;
-      this.siteResolvedProperties = siteListResolvedProp;
+      objTemp[objType].rows = siteList;
+      this.siteResolvedProperties = siteList;
 
       objTemp[objType].page = {
         count: data[dataType].count,

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -175,8 +175,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       this.colsname = this._sitesService.objectObs.dataTable.colNameObj;
       let siteList = this._sitesService.formatLabelTypesSite(data.items);
       this.rows = siteList;
-      const siteListResolvedProp = this._sitesService.formatLabelObservers(siteList);
-      this.siteResolvedProperties = siteListResolvedProp;
+      this.siteResolvedProperties = siteList;
       this.dataTableObj.site.rows = this.siteResolvedProperties;
       this.dataTableObj.site.page.count = data.count;
       this.dataTableObj.site.page.limit = data.limit;
@@ -318,9 +317,8 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       if (objType == 'site') {
         let siteList = this._sitesService.formatLabelTypesSite(data[dataType].data.items);
         this.rows = siteList;
-        const siteListResolvedProp = this._sitesService.formatLabelObservers(siteList);
-        objTemp[objType].rows = siteListResolvedProp;
-        this.siteResolvedProperties = siteListResolvedProp;
+        objTemp[objType].rows = siteList;
+        this.siteResolvedProperties = siteList;
       } else {
         objTemp[objType].rows = data[dataType].data.items;
       }

--- a/frontend/app/components/monitoring-visits/monitoring-visits.component.ts
+++ b/frontend/app/components/monitoring-visits/monitoring-visits.component.ts
@@ -211,8 +211,7 @@ export class MonitoringVisitsComponent extends MonitoringGeomComponent implement
         this.colsname = data.objConfig.objObsVisit.dataTable.colNameObj;
         let siteList = this.siteService.formatLabelTypesSite([this.site]);
         this.objSelected = siteList[0];
-        const siteListResolvedProp = this.siteService.formatLabelObservers(siteList);
-        this.objResolvedProperties = siteListResolvedProp[0];
+        this.objResolvedProperties = siteList[0];
         this.addSpecificConfig();
 
         const { parentObjSelected, objConfig, ...dataonlyObjConfigAndObj } = data;
@@ -269,9 +268,9 @@ export class MonitoringVisitsComponent extends MonitoringGeomComponent implement
   getModules() {
     this.siteService.getSiteModules(this.site.id_base_site).subscribe(
       (data: Module[]) =>
-        (this.modules = data.map((item) => {
-          return { id: item.module_code, label: item.module_label };
-        }))
+      (this.modules = data.map((item) => {
+        return { id: item.module_code, label: item.module_label };
+      }))
     );
   }
 

--- a/frontend/app/interfaces/geom.ts
+++ b/frontend/app/interfaces/geom.ts
@@ -41,8 +41,6 @@ export interface ISite extends IGeomObject {
   dataComplement: JsonData;
   types_site: JsonData[];
   id_sites_group: number;
-  id_inventor: string[];
-  inventor: string[];
 }
 
 export interface ISiteField extends Omit<ISite, 'types_site'> {

--- a/frontend/app/services/api-geom.service.ts
+++ b/frontend/app/services/api-geom.service.ts
@@ -28,7 +28,7 @@ export class ApiService<T = IObject> implements IService<T> {
   constructor(
     protected _cacheService: CacheService,
     protected _configJsonService: ConfigJsonService
-  ) {}
+  ) { }
 
   init(endPoint: endPoints, objectObjs: IobjObs<T>) {
     this.endPoint = endPoint;
@@ -260,27 +260,6 @@ export class SitesService extends ApiGeomService<ISite> {
         }
       }
       rowSitesTable.push({ ...rest_of_site, [varToFormat]: listFieldToUse });
-    }
-    return rowSitesTable;
-  }
-
-  formatLabelObservers(sites: ISiteField[]) {
-    const rowSitesTable: ISiteField[] = [];
-    const varToFormat = 'id_inventor';
-    const varToStore = 'inventor';
-    for (const site of sites) {
-      let listFieldToUse: string[] = [];
-      if (site[varToStore]) {
-        const { [varToStore]: _, ...rest_of_site } = site;
-        for (const item of _) {
-          listFieldToUse.push(item);
-        }
-        rowSitesTable.push({
-          ...rest_of_site,
-          [varToStore]: site[varToStore],
-          [varToFormat]: listFieldToUse,
-        });
-      }
     }
     return rowSitesTable;
   }

--- a/frontend/app/services/cache.service.ts
+++ b/frontend/app/services/cache.service.ts
@@ -1,4 +1,3 @@
-import { ObserversComponent } from '@geonature_common/form/observers/observers.component';
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
@@ -19,7 +18,7 @@ export class CacheService {
   constructor(
     private _http: HttpClient,
     private _config: ConfigService
-  ) {}
+  ) { }
 
   /** http request */
 
@@ -42,13 +41,13 @@ export class CacheService {
 
     const url_params = Object.keys(queryParams).length
       ? '?' +
-        Object.keys(queryParams)
-          .map((key) =>
-            Array.isArray(queryParams[key])
-              ? queryParams[key].map((val) => `${key}=${val}`).join('&')
-              : `${key}=${queryParams[key]}`
-          )
-          .join('&')
+      Object.keys(queryParams)
+        .map((key) =>
+          Array.isArray(queryParams[key])
+            ? queryParams[key].map((val) => `${key}=${val}`).join('&')
+            : `${key}=${queryParams[key]}`
+        )
+        .join('&')
       : '';
     let url: string;
     if (urlRelative.includes('menu_from_code')) {

--- a/frontend/app/services/data-monitoring-object.service.ts
+++ b/frontend/app/services/data-monitoring-object.service.ts
@@ -16,7 +16,7 @@ export class DataMonitoringObjectService {
     private _cacheService: CacheService,
     private _http: HttpClient,
     private _config: ConfigService
-  ) {}
+  ) { }
 
   /**
    * Renvoie la liste des cruved object liés à Monitorings et de l'utilisateur connecté
@@ -157,7 +157,6 @@ export class DataMonitoringObjectService {
    *
    * template :  nom du fichier de template pour l'export pdf (.html)
    * map_image : image de la carte leaflet
-   * id_inventor ???
    *
    **/
   postPdfExport(module_code, object_type, id, template, map_image, extra_data = {}) {


### PR DESCRIPTION
Add the option to have multiple observers on one monitoring site.
The goal is to have the same behavior as the monitoring visits, mainly for access reasons.

For now we can keep the id_inventor field, but IMHO, the two are redundants and observers has the advantage of supporting multiple values.
