### PR TITLE
fix: remove restrictions on type of objects to delete

### DIFF
--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -692,7 +692,7 @@ export class MonitoringFormComponent implements OnInit {
     this.canDelete =
       this.obj.objectType == 'module'
         ? this.currentUser?.moduleCruved[this.obj.objectType]['D'] > 0
-        : this.obj.cruved['D'] && !['site', 'sites_group'].includes(this.obj.objectType);
+        : this.obj.cruved['D'];
     this.canUpdate =
       this.obj.objectType == 'module'
         ? this.currentUser?.moduleCruved[this.obj.objectType]['U'] > 0


### PR DESCRIPTION
Actuellement il est impossible de supprimer des sites ou des groupes de sites monitoring depuis le frontend, même si l'utilisateur a les permissions nécessaires.

Cette PR vise à enlever cette restrictions et permettre aux personnes avec les bonnes permissions de supprimer les groupes de sites ou sites.