### PR TITLE
[DEV-SUIVI-EOLIEN] ci: lint frontend using prettier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,9 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
       - name: Frontend code formatting check (Prettier)
-        uses: creyD/prettier_action@v4.3
-        with:
-          dry: True
-          prettier_version: 3.1.0
-          prettier_options: --config frontend/.prettierrc --check frontend/**/*.ts
+        run: npm install prettier@~3.1.0 && npm run format:check
+        working-directory: ./frontend

--- a/docs/documentation_technique.md
+++ b/docs/documentation_technique.md
@@ -5,3 +5,16 @@
 ## Backend
 
 ## Frontend
+
+Une github action vérifiant le lint du frontend est réalisée .
+En mode développement il est nécessaire d'effectuer avant chaque PR les commandes suivantes :
+
+```sh
+cd frontend # se placer dans le dossier frontend
+nvm use # sourcer la bonne version de node
+npm run format:check # vérifier l'état des fichiers frontend 
+```
+
+La sortie de la commande `npm run format:check` va renvoyer des warning en fonction des fichiers non lintés .
+
+Si c'est le cas , alors lancer la commande : `npm run format`.

--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,9 @@
         "html2canvas": "^1.3.2",
         "protractor": "^7.0.0",
         "tslib": "^1.10.0"
+      },
+      "devDependencies": {
+        "prettier": "~3.1.0"
       }
     },
     "node_modules/@types/q": {
@@ -894,6 +897,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2048,9 +2066,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "ms": {
       "version": "2.1.3",
@@ -2143,6 +2161,12 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
+    },
+    "prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,16 @@
   "description": "Module générique de génération de formulaires de protocoles de suivis",
   "version": "0.2.5",
   "license": "GNU Affero General Public License v3.0",
+  "scripts": {
+    "format:check": "prettier --config .prettierrc --ignore-path .prettierignore --check './**/*.ts'",
+    "format": "prettier --config .prettierrc --ignore-path .prettierignore --write './**/*.ts'"
+  },
   "dependencies": {
     "html2canvas": "^1.3.2",
     "protractor": "^7.0.0",
     "tslib": "^1.10.0"
+  },
+  "devDependencies": {
+    "prettier": "~3.1.0"
   }
 }


### PR DESCRIPTION
Install prettier in dev dependencies
Add nvmrc to manage node package manager version
Create script in package.json for dev check lint

Reviewed-by: andriacap