### PR TITLE
use sitesgroups and sites components

### DIFF
--- a/backend/gn_module_monitoring/monitoring/models.py
+++ b/backend/gn_module_monitoring/monitoring/models.py
@@ -279,6 +279,21 @@ class TMonitoringSites(TBaseSites, PermissionModel, SitesQuery):
 
     data = DB.Column(JSONB)
 
+    modules = DB.relationship(
+        "TMonitoringModules",
+        uselist=True,  # pourquoi pas par defaut ?
+        secondaryjoin=lambda: TMonitoringModules.id_module == cor_module_type.c.id_module,
+        primaryjoin=(id_base_site == cor_site_type.c.id_base_site),
+        secondary=join(
+            cor_site_type,
+            cor_module_type,
+            cor_site_type.c.id_type_site == cor_module_type.c.id_type_site,
+        ),
+        foreign_keys=[cor_site_type.c.id_base_site, cor_module_type.c.id_module],
+        lazy="select",
+        viewonly=True,
+    )
+
     visits = DB.relationship(
         TMonitoringVisits,
         lazy="select",

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -91,6 +91,35 @@ class GnMonitoringGenericFilter:
             scope=cls._get_read_scope(module_code=module_code, object_code=object_code, user=user),
         )
 
+    @classmethod
+    def get_relationship_clause(
+        cls,
+        type,
+    ):
+        join_table = None  # alias de la table de jointure
+        join_column = None  # nom de la colonne permettant la jointure entre data et la table
+        filter_column = None  # nom de la colonne sur lequel le filtre est appliqué
+        if type == "nomenclature":
+            join_table = aliased(TNomenclatures)
+            join_column = join_table.id_nomenclature
+            filter_column = join_table.label_default
+        elif type == "taxonomy":
+            join_table = aliased(Taxref)
+            join_column = join_table.cd_nom
+            filter_column = join_table.nom_vern_or_lb_nom
+        elif type == "user":
+            join_table = aliased(User)
+            join_column = join_table.id_role
+            filter_column = join_table.nom_complet
+        elif type == "area":
+            join_table = aliased(LAreas)
+            join_column = join_table.id_area
+            filter_column = join_table.area_name
+        elif type == "habitat":
+            pass
+
+        return join_table, join_column, filter_column
+
 
 class SitesQuery(GnMonitoringGenericFilter):
     @classmethod
@@ -211,35 +240,6 @@ class SitesQuery(GnMonitoringGenericFilter):
                     query = query.where(cls.data[param].astext.ilike(f"{value}%"))
 
         return query
-
-    @classmethod
-    def get_relationship_clause(
-        cls,
-        type,
-    ):
-        join_table = None  # alias de la table de jointure
-        join_column = None  # nom de la colonne permettant la jointure entre data et la table
-        filter_column = None  # nom de la colonne sur lequel le filtre est appliqué
-        if type == "nomenclature":
-            join_table = aliased(TNomenclatures)
-            join_column = join_table.id_nomenclature
-            filter_column = join_table.label_default
-        elif type == "taxonomy":
-            join_table = aliased(Taxref)
-            join_column = join_table.cd_nom
-            filter_column = join_table.nom_vern_or_lb_nom
-        elif type == "user":
-            join_table = aliased(User)
-            join_column = join_table.id_role
-            filter_column = join_table.nom_complet
-        elif type == "area":
-            join_table = aliased(LAreas)
-            join_column = join_table.id_area
-            filter_column = join_table.area_name
-        elif type == "habitat":
-            pass
-
-        return join_table, join_column, filter_column
 
 
 class SitesGroupsQuery(GnMonitoringGenericFilter):

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -97,7 +97,6 @@ class GnMonitoringGenericFilter:
         query: Select,
         params: MultiDict = None,
         specific_properties: dict = None,
-        **kwargs,
     ):
         """
         Permet d'ajouter les filtres définis dans `params` à la requête SQLA `query`. Les filtres ciblent les propriétés

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -100,15 +100,16 @@ class GnMonitoringGenericFilter:
         **kwargs,
     ):
         """
-        Permet d'ajouter des filtres à la requête des sites
-        en fonction des propriétés spécifiques définies au niveau du module ou des types de sites
+        Permet d'ajouter les filtres définis dans `params` à la requête SQLA `query`. Les filtres ciblent les propriétés
+        spécifiques enregistrées dans le champ JSON `data` du modèle. Les définitions de ces propriétés sont attendues dans
+        `specific_properties` telles que présentes dans les configs.
 
         le principe est pour chaque params (c-a-d filtre) d'extraire le type util et la cardinalité
             et de construire une requête sql en fonction de ces infos
 
         :param query: requête sql initiale
         :param params: liste des paramètres que l'on souhaite filtrer
-        :param specific_properties: Configuration des propriétés spécifiques des sites
+        :param specific_properties: Configuration des propriétés spécifiques
         :return: requête sql amendée de filtre
         """
         for param, value in params.items():

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -125,7 +125,7 @@ class GnMonitoringGenericFilter:
                         multiple = json.loads(multiple_value)
 
                 if type in ("nomenclature", "taxonomy", "user", "area"):
-                    join_table, join_column, filter_column = cls.get_relationship_clause(type)
+                    join_table, join_column, filter_column = cls._get_relationship_clause(type)
                     if multiple:
                         # Si la propriété est de type multiple
                         # Alors jointure sur chaque element de data->'params'
@@ -161,11 +161,8 @@ class GnMonitoringGenericFilter:
 
         return query
 
-    @classmethod
-    def get_relationship_clause(
-        cls,
-        type,
-    ):
+    @staticmethod
+    def _get_relationship_clause(type):
         join_table = None  # alias de la table de jointure
         join_column = None  # nom de la colonne permettant la jointure entre data et la table
         filter_column = None  # nom de la colonne sur lequel le filtre est appliqué

--- a/backend/gn_module_monitoring/monitoring/serializer.py
+++ b/backend/gn_module_monitoring/monitoring/serializer.py
@@ -276,14 +276,16 @@ class MonitoringObjectSerializer(MonitoringObjectBase):
                 # on passe d'une list d'objet à une liste d'id
                 # si type_util est defini pour ce champs
                 # si on a bien affaire à une liste de modèles sqla
-                properties[key] = [
-                    (
-                        getattr(v, id_field_name_dict[type_util])
-                        if (isinstance(v, DB.Model) and type_util)
-                        else v.as_dict() if (isinstance(v, DB.Model) and not type_util) else v
-                    )
-                    for v in value
-                ]
+                new_values = []
+                for v in value:
+                    if isinstance(v, DB.Model):
+                        if type_util:
+                            new_values.append(getattr(v, id_field_name_dict[type_util]))
+                        else:
+                            new_values.append(v.as_dict())
+                    else:
+                        new_values.append(v)
+                properties[key] = new_values
 
         properties["id_parent"] = to_int(self.id_parent())
 

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -214,7 +214,6 @@ def _get_site_geometries(module_code=None):
             params.pop("types_site")
             types_site = None
         else:
-            # FIXME: probably to be removed since the filtering will be done based on the module_code
             params["types_site"] = types_site
 
     if g.current_module:

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -126,7 +126,7 @@ def get_sites(object_type):
     query = filter_params(TMonitoringSites, query=query, params=params)
     query = sort_according_to_column_type_for_site(query, sort_label, sort_dir)
 
-    query_allowed = TMonitoringSites.filter_by_readable(query=query, object_code=object_code)
+    query_allowed = TMonitoringSites.filter_by_readable(query=query, object_code=object_code, module_code=g.current_module.module_code)
     return paginate_scope(
         query=query_allowed,
         schema=MonitoringSitesSchema,

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -112,7 +112,7 @@ def get_all_types_site_from_site_id(id_site, object_type):
 
 
 @blueprint.route("/sites", methods=["GET"], defaults={"object_type": "site"})
-@check_cruved_scope("R", module_code=MODULE_CODE, object_code="MONITORINGS_SITES")
+@check_cruved_scope("R", object_code="MONITORINGS_SITES")
 def get_sites(object_type):
     object_code = "MONITORINGS_SITES"
     params = MultiDict(request.args)

--- a/backend/gn_module_monitoring/routes/site.py
+++ b/backend/gn_module_monitoring/routes/site.py
@@ -135,18 +135,22 @@ def get_sites(object_type, module_code=None):
             TMonitoringSites.modules.any(TMonitoringModules.module_code == module_code)
         )
 
+    config = get_config(g.current_module.module_code)
+    specific_properties = config.get("site", {}).get("specific", {})
+
     query = filter_params(TMonitoringSites, query=query, params=params)
-    query = sort_according_to_column_type_for_site(query, sort_label, sort_dir)
+    query = sort_according_to_column_type_for_site(
+        query, sort_label, sort_dir, specific_properties
+    )
 
     query_allowed = TMonitoringSites.filter_by_readable(
         query=query, object_code=object_code, module_code=g.current_module.module_code
     )
 
-    config = get_config(module_code)
     query_allowed = TMonitoringSites.filter_by_specific(
         query=query_allowed,
         params=params,
-        specific_properties=config.get("site", {}).get("specific", {}),
+        specific_properties=specific_properties,
     )
 
     if module_code:

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -21,7 +21,10 @@ from gn_module_monitoring.monitoring.models import (
     TMonitoringSitesGroups,
     TMonitoringModules,
 )
-from gn_module_monitoring.monitoring.schemas import MonitoringSitesGroupsDetailSchema
+from gn_module_monitoring.monitoring.schemas import (
+    MonitoringSitesGroupsDetailSchema,
+    add_specific_attributes,
+)
 from gn_module_monitoring.utils.errors.errorHandler import InvalidUsage
 from gn_module_monitoring.utils.routes import (
     filter_params,
@@ -47,8 +50,13 @@ def get_config_sites_groups(id=None, module_code="generic", object_type="sites_g
 
 
 @blueprint.route("/sites_groups", methods=["GET"], defaults={"object_type": "sites_group"})
+@blueprint.route(
+    "/refacto/<string:module_code>/sites_groups",
+    methods=["GET"],
+    defaults={"object_type": "sites_group"},
+)
 @check_cruved_scope("R", object_code="MONITORINGS_GRP_SITES")
-def get_sites_groups(object_type: str):
+def get_sites_groups(object_type: str, module_code=None):
     object_code = "MONITORINGS_GRP_SITES"
     params = MultiDict(request.args)
     limit, page = get_limit_page(params=params)
@@ -57,6 +65,12 @@ def get_sites_groups(object_type: str):
         params=params, default_sort="id_sites_group", default_direction="desc"
     )
     query = select(TMonitoringSitesGroups)
+
+    if module_code:
+        query = query.where(
+            TMonitoringSitesGroups.modules.any(TMonitoringModules.module_code == module_code)
+        )
+
     query = filter_params(TMonitoringSitesGroups, query=query, params=params)
 
     # PATCH order by modules
@@ -69,10 +83,27 @@ def get_sites_groups(object_type: str):
     else:
         query = sort(TMonitoringSitesGroups, query=query, sort=sort_label, sort_dir=sort_dir)
 
-    query_allowed = TMonitoringSitesGroups.filter_by_readable(query=query, object_code=object_code, module_code=g.current_module.module_code)
+    query_allowed = TMonitoringSitesGroups.filter_by_readable(
+        query=query, object_code=object_code, module_code=g.current_module.module_code
+    )
+
+    config = get_config(module_code)
+    query_allowed = TMonitoringSitesGroups.filter_by_specific(
+        query=query_allowed,
+        params=params,
+        specific_properties=config.get("sites_group", {}).get("specific", {}),
+    )
+
+    if module_code:
+        schema = add_specific_attributes(
+            MonitoringSitesGroupsDetailSchema, object_type, module_code
+        )
+    else:
+        schema = MonitoringSitesGroupsDetailSchema
+
     return paginate_scope(
         query=query_allowed,
-        schema=MonitoringSitesGroupsDetailSchema,
+        schema=schema,
         limit=limit,
         page=page,
         object_code=object_code,
@@ -108,8 +139,13 @@ def get_sites_group_by_id(scope, id_sites_group: int, object_type: str):
 @blueprint.route(
     "/sites_groups/geometries", methods=["GET"], defaults={"object_type": "sites_group"}
 )
+@blueprint.route(
+    "/refacto/<string:module_code>/sites_groups/geometries",
+    methods=["GET"],
+    defaults={"object_type": "site"},
+)
 @check_cruved_scope("R")
-def get_sites_group_geometries(object_type: str):
+def get_sites_group_geometries(object_type: str, module_code=None):
 
     if g.current_module:
         module_code = g.current_module.module_code
@@ -123,6 +159,11 @@ def get_sites_group_geometries(object_type: str):
         query=query, module_code=module_code, object_code=object_code
     )
     query = TMonitoringSitesGroups.filter_by_params(query=query, params=params)
+
+    if module_code != MODULE_CODE:
+        query = query.where(
+            TMonitoringSitesGroups.modules.any(TMonitoringModules.module_code == module_code)
+        )
 
     alias_sites = aliased(TMonitoringSites)
     subquery_not_geom = (

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -69,7 +69,7 @@ def get_sites_groups(object_type: str):
     else:
         query = sort(TMonitoringSitesGroups, query=query, sort=sort_label, sort_dir=sort_dir)
 
-    query_allowed = TMonitoringSitesGroups.filter_by_readable(query=query, object_code=object_code)
+    query_allowed = TMonitoringSitesGroups.filter_by_readable(query=query, object_code=object_code, module_code=g.current_module.module_code)
     return paginate_scope(
         query=query_allowed,
         schema=MonitoringSitesGroupsDetailSchema,

--- a/backend/gn_module_monitoring/routes/sites_groups.py
+++ b/backend/gn_module_monitoring/routes/sites_groups.py
@@ -47,7 +47,7 @@ def get_config_sites_groups(id=None, module_code="generic", object_type="sites_g
 
 
 @blueprint.route("/sites_groups", methods=["GET"], defaults={"object_type": "sites_group"})
-@check_cruved_scope("R", module_code=MODULE_CODE, object_code="MONITORINGS_GRP_SITES")
+@check_cruved_scope("R", object_code="MONITORINGS_GRP_SITES")
 def get_sites_groups(object_type: str):
     object_code = "MONITORINGS_GRP_SITES"
     params = MultiDict(request.args)

--- a/backend/gn_module_monitoring/tests/fixtures/TestData/config_type_site.json
+++ b/backend/gn_module_monitoring/tests/fixtures/TestData/config_type_site.json
@@ -101,6 +101,13 @@
         "type_widget": "textarea",
         "attribut_label": "Mesure(s) préconisé(s)",
         "rows": 3
+      },
+      "meteo_gite": {
+        "type_widget": "nomenclature",
+        "attribut_label": "test météo gîte",
+        "code_nomenclature_type": "TEST_METEO",
+        "type_util": "nomenclature",
+        "required": false
       }
     }
   }

--- a/backend/gn_module_monitoring/tests/fixtures/generic.py
+++ b/backend/gn_module_monitoring/tests/fixtures/generic.py
@@ -8,51 +8,124 @@ from geonature.core.gn_permissions.models import (
 )
 from geonature.core.gn_commons.models import TModules
 
+from pypnusershub.db.models import User
+from pypnusershub.db.models import (
+    User,
+    Organisme,
+    Application,
+    Profils as Profil,
+    UserApplicationRight,
+)
 
-def add_user_permission(module_code, user, scope, type_code_object, code_action="CRUVED"):
-    """
-    Add permissions to a user in a module.
+from gn_module_monitoring.monitoring.models import TMonitoringModules
 
-    Parameters
-    ----------
-    module_code : str
-        Code of the module to add the permission to.
-    user : User
-        User to add the permission to.
-    scope : int
-        Scope value for the permission.
-    type_code_object : str
-        Type of the object to add the permission to.
-    code_action : str, optional
-        Code of the action to add the permission for. Default is "CRUVED".
 
-    Notes
-    -----
-    The function will add the permission to the specified module and object with the given scope.
-    If the scope is 3, the scope_value will be set to None.
-    """
-    module = db.session.execute(
-        select(TModules).where(TModules.module_code == module_code)
-    ).scalar_one()
-    actions = {
-        code: db.session.execute(
-            select(PermAction).where(PermAction.code_action == code)
+@pytest.fixture(scope="session")
+def create_user():
+    def _create_user(
+        username,
+        organisme=None,
+        scope=None,
+        sensitivity_filter=False,
+        modules=None,
+    ):
+        app = db.session.execute(
+            select(Application).where(Application.code_application == "GN")
         ).scalar_one()
-        for code in code_action
-    }
-    with db.session.begin_nested():
-        if scope > 0:
-            object_all = db.session.scalars(
-                select(PermObject).where(PermObject.code_object == type_code_object)
-            ).all()
-            for action in actions.values():
-                for obj in object_all + module.objects:
-                    permission = Permission(
-                        role=user,
-                        action=action,
-                        module=module,
-                        object=obj,
-                        scope_value=scope if scope != 3 else None,
-                        sensitivity_filter=None,
-                    )
-                    db.session.add(permission)
+        profil = db.session.execute(
+            select(Profil).where(Profil.nom_profil == "Lecteur")
+        ).scalar_one()
+
+        if not modules:
+            modules = db.session.scalars(select(TModules)).all()
+
+        actions = {
+            code: db.session.execute(
+                select(PermAction).where(PermAction.code_action == code)
+            ).scalar_one()
+            for code in "CRUVED"
+        }
+
+        type_code_object = [
+            "MONITORINGS_MODULES",
+            "MONITORINGS_GRP_SITES",
+            "MONITORINGS_SITES",
+            "MONITORINGS_VISITES",
+            "ALL",
+        ]
+
+        # do not commit directly on current transaction, as we want to rollback all changes at the end of tests
+        with db.session.begin_nested():
+            user = User(
+                groupe=False,
+                active=True,
+                organisme=organisme,
+                identifiant=username,
+                password=username,
+                nom_role=username,
+                prenom_role=username,
+            )
+            db.session.add(user)
+        # user must have been commited for user.id_role to be defined
+        with db.session.begin_nested():
+            # login right
+            right = UserApplicationRight(
+                id_role=user.id_role, id_application=app.id_application, id_profil=profil.id_profil
+            )
+            db.session.add(right)
+            if scope > 0:
+                for co in type_code_object:
+                    object_all = db.session.scalars(
+                        select(PermObject).where(PermObject.code_object == co)
+                    ).all()
+                    for action in actions.values():
+                        for module in modules:
+                            for obj in object_all + module.objects:
+                                permission = Permission(
+                                    role=user,
+                                    action=action,
+                                    module=module,
+                                    object=obj,
+                                    scope_value=scope if scope != 3 else None,
+                                    sensitivity_filter=sensitivity_filter,
+                                )
+                                db.session.add(permission)
+        return user
+
+    return _create_user
+
+
+@pytest.fixture(scope="session")
+def monitorings_users(app, create_user):
+    organisme = Organisme(nom_organisme="Autre")
+    db.session.add(organisme)
+    users = {}
+    users_to_create = [
+        ("noright_user", organisme, 0),
+        ("stranger_user", None, 2),
+        ("associate_user", organisme, 2),
+        ("self_user", organisme, 1),
+        ("user", organisme, 2),
+        ("admin_user", organisme, 3),
+    ]
+    for username, *args in users_to_create:
+        users[username] = create_user(username, *args)
+    return users
+
+
+@pytest.fixture()
+def create_test_module_user(install_module_test, create_user):
+    """user with right to read MONITORINGS_SITES of the test module because she is the digitiser of the sites"""
+
+    def _create_test_module_user():
+        module = db.session.execute(
+            select(TMonitoringModules).where(TMonitoringModules.module_code == "test")
+        ).scalar()
+        return create_user("test_module_user", scope=1, modules=[module])
+
+    return _create_test_module_user
+
+
+@pytest.fixture()
+def test_module_user(create_test_module_user):
+    return create_test_module_user()

--- a/backend/gn_module_monitoring/tests/fixtures/generic.py
+++ b/backend/gn_module_monitoring/tests/fixtures/generic.py
@@ -1,5 +1,5 @@
 from sqlalchemy import select
-
+import pytest
 from geonature.utils.env import db
 from geonature.core.gn_permissions.models import (
     PermAction,
@@ -20,6 +20,57 @@ from pypnusershub.db.models import (
 from gn_module_monitoring.monitoring.models import TMonitoringModules
 
 
+def add_user_permission(
+    module_code, user, scope, type_code_object, code_action="CRUVED", sensitivity_filter=None
+):
+    """
+    Add permissions to a user in a module.
+
+    Parameters
+    ----------
+    module_code : str
+        Code of the module to add the permission to.
+    user : User
+        User to add the permission to.
+    scope : int
+        Scope value for the permission.
+    type_code_object : str
+        Type of the object to add the permission to.
+    code_action : str, optional
+        Code of the action to add the permission for. Default is "CRUVED".
+
+    Notes
+    -----
+    The function will add the permission to the specified module and object with the given scope.
+    If the scope is 3, the scope_value will be set to None.
+    """
+    module = db.session.execute(
+        select(TModules).where(TModules.module_code == module_code)
+    ).scalar_one()
+    actions = {
+        code: db.session.execute(
+            select(PermAction).where(PermAction.code_action == code)
+        ).scalar_one()
+        for code in code_action
+    }
+    with db.session.begin_nested():
+        if scope > 0:
+            object_all = db.session.scalars(
+                select(PermObject).where(PermObject.code_object == type_code_object)
+            ).all()
+            for action in actions.values():
+                for obj in object_all + module.objects:
+                    permission = Permission(
+                        role=user,
+                        action=action,
+                        module=module,
+                        object=obj,
+                        scope_value=scope if scope != 3 else None,
+                        sensitivity_filter=sensitivity_filter,
+                    )
+                    db.session.add(permission)
+
+
 @pytest.fixture(scope="session")
 def create_user():
     def _create_user(
@@ -38,13 +89,6 @@ def create_user():
 
         if not modules:
             modules = db.session.scalars(select(TModules)).all()
-
-        actions = {
-            code: db.session.execute(
-                select(PermAction).where(PermAction.code_action == code)
-            ).scalar_one()
-            for code in "CRUVED"
-        }
 
         type_code_object = [
             "MONITORINGS_MODULES",
@@ -73,49 +117,26 @@ def create_user():
                 id_role=user.id_role, id_application=app.id_application, id_profil=profil.id_profil
             )
             db.session.add(right)
-            if scope > 0:
-                for co in type_code_object:
-                    object_all = db.session.scalars(
-                        select(PermObject).where(PermObject.code_object == co)
-                    ).all()
-                    for action in actions.values():
-                        for module in modules:
-                            for obj in object_all + module.objects:
-                                permission = Permission(
-                                    role=user,
-                                    action=action,
-                                    module=module,
-                                    object=obj,
-                                    scope_value=scope if scope != 3 else None,
-                                    sensitivity_filter=sensitivity_filter,
-                                )
-                                db.session.add(permission)
+
+        for module in modules:
+            for code_object in type_code_object:
+                add_user_permission(
+                    module.module_code,
+                    user,
+                    scope,
+                    code_object,
+                    code_action="CRUVED",
+                    sensitivity_filter=sensitivity_filter,
+                )
+
         return user
 
     return _create_user
 
 
-@pytest.fixture(scope="session")
-def monitorings_users(app, create_user):
-    organisme = Organisme(nom_organisme="Autre")
-    db.session.add(organisme)
-    users = {}
-    users_to_create = [
-        ("noright_user", organisme, 0),
-        ("stranger_user", None, 2),
-        ("associate_user", organisme, 2),
-        ("self_user", organisme, 1),
-        ("user", organisme, 2),
-        ("admin_user", organisme, 3),
-    ]
-    for username, *args in users_to_create:
-        users[username] = create_user(username, *args)
-    return users
-
-
 @pytest.fixture()
 def create_test_module_user(install_module_test, create_user):
-    """user with right to read MONITORINGS_SITES of the test module because she is the digitiser of the sites"""
+    """user with right to read MONITORINGS_SITES of the test module because he is the digitiser of the sites"""
 
     def _create_test_module_user():
         module = db.session.execute(

--- a/backend/gn_module_monitoring/tests/fixtures/module.py
+++ b/backend/gn_module_monitoring/tests/fixtures/module.py
@@ -75,6 +75,12 @@ def install_module_test(types_site, users):
                 code_action="CRUVD",
             )
 
+    # This is required because the first call to get_config during the install command cannot get the site types
+    # (because the module does not exist yet in the DB) but this incomplete config is still registered with the cache.
+    from gn_module_monitoring.config.repositories import get_config
+
+    get_config("test", force=True)
+
 
 @pytest.fixture
 def monitoring_module(types_site, users):

--- a/backend/gn_module_monitoring/tests/fixtures/site.py
+++ b/backend/gn_module_monitoring/tests/fixtures/site.py
@@ -29,6 +29,7 @@ def sites(users, types_site, site_group_with_sites):
             geom=geom_4326,
             types_site=[types_site[key]],
             id_sites_group=site_group_with_sites.id_sites_group,
+            data={"profondeur_grotte": 42.8, "owner_name": "Robert", "meteo": 2},
         )
 
     for i, key in enumerate(types_site.keys()):

--- a/backend/gn_module_monitoring/tests/fixtures/sites_groups.py
+++ b/backend/gn_module_monitoring/tests/fixtures/sites_groups.py
@@ -1,8 +1,9 @@
 import pytest
 
-from geonature.utils.env import db
+from sqlalchemy import select
 
-from gn_module_monitoring.monitoring.models import TMonitoringSitesGroups
+from geonature.utils.env import db
+from gn_module_monitoring.monitoring.models import TMonitoringSitesGroups, TMonitoringModules
 
 
 @pytest.fixture
@@ -25,3 +26,22 @@ def site_group_with_sites(sites_groups):
 @pytest.fixture
 def site_group_without_sites(sites_groups):
     return sites_groups["Site_eolien"]
+
+
+@pytest.fixture
+def sites_groups_with_module(install_module_test):
+    names = ["Site_eolien", "Site_Groupe"]
+
+    module = db.session.execute(
+        select(TMonitoringModules).where(TMonitoringModules.module_code == "test")
+    ).scalar()
+
+    groups = {name: TMonitoringSitesGroups(sites_group_name=name) for name in names}
+
+    for group in groups.values():
+        group.modules.append(module)
+
+    with db.session.begin_nested():
+        db.session.add_all(groups.values())
+
+    return groups

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -460,41 +460,40 @@ class TestSite:
         assert "404 Not Found" in str(e.value)
 
 
-@pytest.fixture()
-def add_site(test_module_user, types_site, site_group_with_sites):
+# @pytest.fixture()
+# def add_site(test_module_user, types_site, site_group_with_sites):
+#
+#     def _add_site(**kwargs):
+#         _add_site.counter += 1
+#         i = _add_site.counter
+#         user = test_module_user
+#         geom_4326 = from_shape(Point(43, 24), srid=4326)
+#         args = {
+#             "id_inventor": user.id_role,
+#             "id_digitiser": user.id_role,
+#             "base_site_name": f"Site{i}",
+#             "base_site_description": f"Description{i}",
+#             "base_site_code": f"Code{i}",
+#             "geom": geom_4326,
+#             "types_site": list(types_site.values()),
+#             "id_sites_group": site_group_with_sites.id_sites_group,
+#         }
+#         args.update(**kwargs)
+#         site = TMonitoringSites(**args)
+#         with db.session.begin_nested():
+#             db.session.add(site)
+#         return site
+#
+#     _add_site.counter = 0
+#
+#     return _add_site
 
-    def _add_site(**kwargs):
-        _add_site.counter += 1
-        i = _add_site.counter
-        user = test_module_user
-        geom_4326 = from_shape(Point(43, 24), srid=4326)
-        args = {
-            "id_inventor": user.id_role,
-            "id_digitiser": user.id_role,
-            "base_site_name": f"Site{i}",
-            "base_site_description": f"Description{i}",
-            "base_site_code": f"Code{i}",
-            "geom": geom_4326,
-            "types_site": list(types_site.values()),
-            "id_sites_group": site_group_with_sites.id_sites_group,
-        }
-        args.update(**kwargs)
-        site = TMonitoringSites(**args)
-        with db.session.begin_nested():
-            db.session.add(site)
-        return site
 
-    _add_site.counter = 0
-
-    return _add_site
-
-
-@pytest.mark.usefixtures("client_class", "temporary_transaction")
+@pytest.mark.usefixtures("client_class", "temporary_transaction", "install_module_test")
 class TestSiteWithModule:
 
     def test_get_module_sites(
         self,
-        install_module_test,
         test_module_user,
         types_site,
         add_site,
@@ -537,9 +536,7 @@ class TestSiteWithModule:
         # ID retourné pour attribut spécifique du site
         assert site_repr.get("meteo") == 2
 
-    def test_get_module_sites_with_filter_on_generic_attribute(
-        self, install_module_test, test_module_user, add_site
-    ):
+    def test_get_module_sites_with_filter_on_generic_attribute(self, test_module_user, add_site):
         set_logged_user_cookie(self.client, test_module_user)
         filter_params = {"base_site_name": "gr"}
         add_site(base_site_name="Grotte")  # Sera retourné avec le filtre
@@ -558,7 +555,7 @@ class TestSiteWithModule:
         assert site_repr["base_site_name"] == "Grotte"
 
     def test_get_module_sites_with_filter_on_site_specific_attribute(
-        self, install_module_test, test_module_user, add_site
+        self, test_module_user, add_site
     ):
         set_logged_user_cookie(self.client, test_module_user)
         filter_params = {"profondeur_grotte": "48"}
@@ -580,7 +577,7 @@ class TestSiteWithModule:
         assert site_2.id_base_site in sites_ids
 
     def test_get_module_sites_with_filter_on_site_type_specific_attribute(
-        self, install_module_test, test_module_user, add_site
+        self, test_module_user, add_site
     ):
         set_logged_user_cookie(self.client, test_module_user)
         filter_params = {"place_name": "to"}
@@ -601,7 +598,7 @@ class TestSiteWithModule:
         assert site_1.id_base_site in sites_ids
 
     def test_get_module_sites_with_filter_on_site_specific_nomenclature_attribute(
-        self, install_module_test, test_module_user, add_site
+        self, test_module_user, add_site
     ):
         set_logged_user_cookie(self.client, test_module_user)
         beau = self._get_meteo_value("Beau")
@@ -622,7 +619,7 @@ class TestSiteWithModule:
         assert site.id_base_site in sites_ids
 
     def test_get_module_sites_with_filter_on_site_type_specific_nomenclature_attribute(
-        self, install_module_test, test_module_user, add_site
+        self, test_module_user, add_site
     ):
         set_logged_user_cookie(self.client, test_module_user)
         beau = self._get_meteo_value("Beau")
@@ -643,7 +640,7 @@ class TestSiteWithModule:
         assert site.id_base_site in sites_ids
 
     def test_get_module_sites_with_filter_on_site_nb_visits(
-        self, install_module_test, test_module_user, add_site, datasets
+        self, test_module_user, add_site, datasets
     ):
         set_logged_user_cookie(self.client, test_module_user)
         filter_params = {"nb_visits": 2}
@@ -683,7 +680,7 @@ class TestSiteWithModule:
         ],
     )
     def test_get_module_sites_ordering_by_generic_property(
-        self, install_module_test, test_module_user, add_site, page, dir, expected_names
+        self, test_module_user, add_site, page, dir, expected_names
     ):
         set_logged_user_cookie(self.client, test_module_user)
         add_site(base_site_name="arbre")
@@ -721,7 +718,7 @@ class TestSiteWithModule:
         ],
     )
     def test_get_module_sites_ordering_by_text_specific_property(
-        self, install_module_test, test_module_user, add_site, page, dir, expected_names
+        self, test_module_user, add_site, page, dir, expected_names
     ):
         set_logged_user_cookie(self.client, test_module_user)
         add_site(data={"contact_name": "Robert"})
@@ -757,7 +754,7 @@ class TestSiteWithModule:
         ],
     )
     def test_get_module_sites_ordering_by_text_specific_property(
-        self, install_module_test, test_module_user, add_site, page, dir, expected_names
+        self, test_module_user, add_site, page, dir, expected_names
     ):
         set_logged_user_cookie(self.client, test_module_user)
         add_site(data={"contact_name": "Robert"})
@@ -793,7 +790,7 @@ class TestSiteWithModule:
         ],
     )
     def test_get_module_sites_ordering_by_nomenclature_specific_property(
-        self, install_module_test, test_module_user, add_site, page, dir, expected_meteo_values
+        self, test_module_user, add_site, page, dir, expected_meteo_values
     ):
         set_logged_user_cookie(self.client, test_module_user)
         meteo_map = {
@@ -850,3 +847,31 @@ class TestSiteWithModule:
             .where(BibNomenclaturesTypes.mnemonique == "TEST_METEO")
             .where(TNomenclatures.mnemonique == mnemonique)
         ).scalar()
+
+    @pytest.fixture
+    def add_site(self, test_module_user, types_site, site_group_with_sites):
+
+        def _add_site(**kwargs):
+            _add_site.counter += 1
+            i = _add_site.counter
+            user = test_module_user
+            geom_4326 = from_shape(Point(43, 24), srid=4326)
+            args = {
+                "id_inventor": user.id_role,
+                "id_digitiser": user.id_role,
+                "base_site_name": f"Site{i}",
+                "base_site_description": f"Description{i}",
+                "base_site_code": f"Code{i}",
+                "geom": geom_4326,
+                "types_site": list(types_site.values()),
+                "id_sites_group": site_group_with_sites.id_sites_group,
+            }
+            args.update(**kwargs)
+            site = TMonitoringSites(**args)
+            with db.session.begin_nested():
+                db.session.add(site)
+            return site
+
+        _add_site.counter = 0
+
+        return _add_site

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -489,7 +489,6 @@ class TestSite:
 #     return _add_site
 
 
-
 # TODO: ajouter tests sur filtre par permissions
 @pytest.mark.usefixtures("client_class", "temporary_transaction", "install_module_test")
 class TestSiteWithModule:

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -489,6 +489,8 @@ class TestSite:
 #     return _add_site
 
 
+
+# TODO: ajouter tests sur filtre par permissions
 @pytest.mark.usefixtures("client_class", "temporary_transaction", "install_module_test")
 class TestSiteWithModule:
 

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -671,6 +671,160 @@ class TestSiteWithModule:
         assert site2.id_base_site in sites_repr_ids
         assert site3.id_base_site in sites_repr_ids
 
+    @pytest.mark.parametrize(
+        "page,dir,expected_names",
+        [
+            (1, "asc", ["abri", "arbre"]),
+            (2, "asc", ["garage", "grange"]),
+            (3, "asc", ["grotte"]),
+            (1, "desc", ["grotte", "grange"]),
+            (2, "desc", ["garage", "arbre"]),
+            (3, "desc", ["abri"]),
+        ],
+    )
+    def test_get_module_sites_ordering_by_generic_property(
+        self, install_module_test, test_module_user, add_site, page, dir, expected_names
+    ):
+        set_logged_user_cookie(self.client, test_module_user)
+        add_site(base_site_name="arbre")
+        add_site(base_site_name="grange")
+        add_site(base_site_name="abri")
+        add_site(base_site_name="grotte")
+        add_site(base_site_name="garage")
+
+        response = self.client.get(
+            url_for(
+                "monitorings.get_sites",
+                module_code="test",
+                sort="base_site_name",
+                sort_dir=dir,
+                page=page,
+                limit=2,
+            )
+        )
+
+        assert response.status_code == 200
+        sites_response = response.json["items"]
+        assert len(sites_response) == len(expected_names)
+        for i, name in enumerate(expected_names):
+            assert sites_response[i]["base_site_name"] == name
+
+    @pytest.mark.parametrize(
+        "page,dir,expected_names",
+        [
+            (1, "asc", ["Alain", "Alice"]),
+            (2, "asc", ["Robert", "Roger"]),
+            (3, "asc", ["Sarah"]),
+            (1, "desc", ["Sarah", "Roger"]),
+            (2, "desc", ["Robert", "Alice"]),
+            (3, "desc", ["Alain"]),
+        ],
+    )
+    def test_get_module_sites_ordering_by_text_specific_property(
+        self, install_module_test, test_module_user, add_site, page, dir, expected_names
+    ):
+        set_logged_user_cookie(self.client, test_module_user)
+        add_site(data={"contact_name": "Robert"})
+        add_site(data={"contact_name": "Alice"})
+        add_site(data={"contact_name": "Roger"})
+        add_site(data={"contact_name": "Alain"})
+        add_site(data={"contact_name": "Sarah"})
+
+        response = self.client.get(
+            url_for(
+                "monitorings.get_sites",
+                module_code="test",
+                sort="contact_name",
+                sort_dir=dir,
+                page=page,
+                limit=2,
+            )
+        )
+        assert response.status_code == 200
+        sites_response = response.json["items"]
+        names_response = [s["contact_name"] for s in sites_response]
+        assert names_response == expected_names
+
+    @pytest.mark.parametrize(
+        "page,dir,expected_names",
+        [
+            (1, "asc", ["Alain", "Alice"]),
+            (2, "asc", ["Robert", "Roger"]),
+            (3, "asc", ["Sarah"]),
+            (1, "desc", ["Sarah", "Roger"]),
+            (2, "desc", ["Robert", "Alice"]),
+            (3, "desc", ["Alain"]),
+        ],
+    )
+    def test_get_module_sites_ordering_by_text_specific_property(
+        self, install_module_test, test_module_user, add_site, page, dir, expected_names
+    ):
+        set_logged_user_cookie(self.client, test_module_user)
+        add_site(data={"contact_name": "Robert"})
+        add_site(data={"contact_name": "Alice"})
+        add_site(data={"contact_name": "Roger"})
+        add_site(data={"contact_name": "Alain"})
+        add_site(data={"contact_name": "Sarah"})
+
+        response = self.client.get(
+            url_for(
+                "monitorings.get_sites",
+                module_code="test",
+                sort="contact_name",
+                sort_dir=dir,
+                page=page,
+                limit=2,
+            )
+        )
+        assert response.status_code == 200
+        sites_response = response.json["items"]
+        names_response = [s["contact_name"] for s in sites_response]
+        assert names_response == expected_names
+
+    @pytest.mark.parametrize(
+        "page,dir,expected_meteo_values",
+        [
+            (1, "asc", ["Beau", "Beau"]),
+            (2, "asc", ["Mauvais", "Nuageux"]),
+            (3, "asc", ["Nuageux"]),
+            (1, "desc", ["Nuageux", "Nuageux"]),
+            (2, "desc", ["Mauvais", "Beau"]),
+            (3, "desc", ["Beau"]),
+        ],
+    )
+    def test_get_module_sites_ordering_by_nomenclature_specific_property(
+        self, install_module_test, test_module_user, add_site, page, dir, expected_meteo_values
+    ):
+        set_logged_user_cookie(self.client, test_module_user)
+        meteo_map = {
+            "Beau": self._get_meteo_value("Beau"),
+            "Mauvais": self._get_meteo_value("Mauvais"),
+            "Nuageux": self._get_meteo_value("Nuageux"),
+        }
+        add_site(data={"meteo": meteo_map["Nuageux"].id_nomenclature})
+        add_site(data={"meteo": meteo_map["Beau"].id_nomenclature})
+        add_site(data={"meteo": meteo_map["Nuageux"].id_nomenclature})
+        add_site(data={"meteo": meteo_map["Mauvais"].id_nomenclature})
+        add_site(data={"meteo": meteo_map["Beau"].id_nomenclature})
+
+        response = self.client.get(
+            url_for(
+                "monitorings.get_sites",
+                module_code="test",
+                sort="meteo",
+                sort_dir=dir,
+                page=page,
+                limit=2,
+            )
+        )
+        assert response.status_code == 200
+        sites_response = response.json["items"]
+        sites_meteos = [s["meteo"] for s in sites_response]
+        expected_meteo_ids = [
+            self._get_meteo_value(m).id_nomenclature for m in expected_meteo_values
+        ]
+        assert sites_meteos == expected_meteo_ids
+
     @staticmethod
     def add_visit(site, dataset):
         module = db.session.execute(

--- a/backend/gn_module_monitoring/tests/test_routes/test_sites_groups.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_sites_groups.py
@@ -92,6 +92,8 @@ class TestSitesGroups:
         assert id_ == site_group_with_sites.id_sites_group
 
 
+# TODO: ajouter tests sur tri
+# TODO: ajouter tests sur filtre par permissions
 @pytest.mark.usefixtures("client_class", "temporary_transaction", "install_module_test")
 class TestSitesGroupsWithModule:
 

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -169,7 +169,12 @@ def sort_according_to_column_type_for_site(query, sort_label, sort_dir):
         else:
             query = query.order_by(User.nom_complet.desc())
     else:
-        query = sort(TMonitoringSites, query=query, sort=sort_label, sort_dir=sort_dir)
+        query = sort(
+            TMonitoringSites,
+            query=query,
+            sort=sort_label,
+            sort_dir=sort_dir,
+        )
     return query
 
 

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -99,6 +99,7 @@ def sort(
         return query.order_by(order_by)
     elif specific_properties and sort in specific_properties:
         field = specific_properties.get(sort)
+        # TODO: implémenter les autres type_util
         if field.get("type_util") == "nomenclature":
             join_table, join_column, filter_column = model._get_relationship_clause(
                 type="nomenclature"

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ from geonature.tests.fixtures import *
 from geonature.tests.fixtures import _session, app, _app, users
 
 pytest_plugins = [
+    "gn_module_monitoring.tests.fixtures.generic",
     "gn_module_monitoring.tests.fixtures.module",
     "gn_module_monitoring.tests.fixtures.site",
     "gn_module_monitoring.tests.fixtures.sites_groups",

--- a/contrib/test/nomenclature.json
+++ b/contrib/test/nomenclature.json
@@ -9,17 +9,24 @@
   "nomenclatures": [
     {
       "type":"TEST_METEO",
-      "cd_nomenclature": "METEO_B",
-      "mnemonique": "Beau",
-      "label_default": "Beau temps",
-      "definition_default": "Beau temps (test)"
-    },
-    {
-      "type":"TEST_METEO",
       "cd_nomenclature": "METEO_M",
       "mnemonique": "Mauvais",
       "label_default": "Mauvais temps",
       "definition_default": "Mauvais temps (test)"
+    },
+    {
+      "type":"TEST_METEO",
+      "cd_nomenclature": "METEO_N",
+      "mnemonique": "Nuageux",
+      "label_default": "Temps nuageux",
+      "definition_default": "Temps nuageux (test)"
+    },
+    {
+      "type":"TEST_METEO",
+      "cd_nomenclature": "METEO_B",
+      "mnemonique": "Beau",
+      "label_default": "Beau temps",
+      "definition_default": "Beau temps (test)"
     },
     {
       "type": "TEST_UNKWONW_TYPE",

--- a/contrib/test/site.json
+++ b/contrib/test/site.json
@@ -56,6 +56,13 @@
           "cd_typo": 7,
           "search_name": ""
       }
+    },
+    "meteo": {
+      "type_widget": "nomenclature",
+      "attribut_label": "test météo",
+      "code_nomenclature_type": "TEST_METEO",
+      "type_util": "nomenclature",
+      "required": false
     }
   }
 }

--- a/contrib/test/sites_group.json
+++ b/contrib/test/sites_group.json
@@ -1,0 +1,15 @@
+{
+  "specific": {
+    "group_specific": {
+      "type_widget": "text",
+      "attribut_label": "Attribut spécifique des groupes"
+    },
+    "group_specific_meteo": {
+      "type_widget": "nomenclature",
+      "attribut_label": "test météo",
+      "code_nomenclature_type": "TEST_METEO",
+      "type_util": "nomenclature",
+      "required": false
+    }
+  }
+}

--- a/frontend/app/components/breadcrumbs/breadcrumbs.component.ts
+++ b/frontend/app/components/breadcrumbs/breadcrumbs.component.ts
@@ -90,19 +90,16 @@ export class BreadcrumbsComponent implements OnInit {
             'monitorings',
             'object',
             elem.module_code,
-            elem.object_type === "module" ? "sites_group" : elem.object_type,
+            elem.object_type === 'module' ? 'sites_group' : elem.object_type,
           ];
 
-          if (!(elem.object_type === "module")) {
+          if (!(elem.object_type === 'module')) {
             path.push(elem.id);
           }
 
-          this._router.navigate(
-            path,
-            {
-              queryParams: elem.params,
-            }
-          );
+          this._router.navigate(path, {
+            queryParams: elem.params,
+          });
         }
       } else {
         this._router.navigate([this._configService.frontendModuleMonitoringUrl()]);

--- a/frontend/app/components/breadcrumbs/breadcrumbs.component.ts
+++ b/frontend/app/components/breadcrumbs/breadcrumbs.component.ts
@@ -81,19 +81,25 @@ export class BreadcrumbsComponent implements OnInit {
   onClick(elem) {
     this.bEditChange.emit(false);
     setTimeout(() => {
+      console.log(this.obj, elem);
       if (elem) {
         if (this.obj == undefined) {
           const url = [this._configService.frontendModuleMonitoringUrl(), elem.url].join('/');
           this._router.navigateByUrl(url);
         } else {
+          const path = [
+            'monitorings',
+            'object',
+            elem.module_code,
+            elem.object_type === "module" ? "sites_group" : elem.object_type,
+          ];
+
+          if (!(elem.object_type === "module")) {
+            path.push(elem.id);
+          }
+
           this._router.navigate(
-            [
-              this._configService.frontendModuleMonitoringUrl(),
-              'object',
-              elem.module_code,
-              elem.object_type,
-              elem.id,
-            ],
+            path,
             {
               queryParams: elem.params,
             }

--- a/frontend/app/components/breadcrumbs/breadcrumbs.component.ts
+++ b/frontend/app/components/breadcrumbs/breadcrumbs.component.ts
@@ -81,7 +81,6 @@ export class BreadcrumbsComponent implements OnInit {
   onClick(elem) {
     this.bEditChange.emit(false);
     setTimeout(() => {
-      console.log(this.obj, elem);
       if (elem) {
         if (this.obj == undefined) {
           const url = [this._configService.frontendModuleMonitoringUrl(), elem.url].join('/');

--- a/frontend/app/components/modules/modules.component.html
+++ b/frontend/app/components/modules/modules.component.html
@@ -41,7 +41,7 @@
             style="min-width: 250px; max-width: 250px"
             *ngFor="let module of modules"
           >
-            <a [routerLink]="['object', module.module_code, 'module', module.id_module]">
+            <a [routerLink]="['object', module.module_code, 'sites_group']">
               <div class="card module-card" title="code&nbsp;: {{ module.module_code }}">
                 <img
                   class="card-img-top"

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -137,12 +137,11 @@ export class MonitoringDatatableGComponent implements OnInit {
     this.activetabIndex = tab.index;
     // Réinitialisation des données selectés
     this.activetabType = this.dataTableArray[tab.index].objectType;
-    this.dataTableObj[this.activetabType].rows.length > 0
-      ? (this.columns = this._dataTableService.colsTable(
-          this.dataTableObj[this.activetabType].columns,
-          this.dataTableObj[this.activetabType].rows[0]
-        ))
-      : null;
+    this.columns =
+      this.dataTableObj[this.activetabType].rows.length > 0
+        ? this._dataTableService.colsTable(this.dataTableObj[this.activetabType].columns)
+        : null;
+
     this.rows = this.dataTableObj[this.activetabType].rows;
     this.page = this.dataTableObj[this.activetabType].page;
     this.objectsStatusChange.emit(this.reInitStatut());
@@ -326,9 +325,9 @@ export class MonitoringDatatableGComponent implements OnInit {
 
       this.activetabType = this.dataTableArray[this.activetabIndex].objectType;
       const dataTable = this.dataTableObj[this.activetabType];
-      if (dataTable.rows.length > 0) {
-        this.columns = this._dataTableService.colsTable(dataTable.columns, dataTable.rows[0]);
-      }
+      this.columns =
+        dataTable.rows.length > 0 ? this._dataTableService.colsTable(dataTable.columns) : null;
+
       this.rows = dataTable.rows;
       this.page = dataTable.page;
       this.initPermissionAction();
@@ -339,6 +338,7 @@ export class MonitoringDatatableGComponent implements OnInit {
     if (this.rows && this.rows.length > 0) {
       this.activetabType = this.dataTableArray[this.activetabIndex].objectType;
       const dataTable = this.dataTableObj[this.activetabType];
+
       this.rows = dataTable.rows;
       this.page = dataTable.page;
       this.initPermissionAction();

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -173,7 +173,7 @@ export class MonitoringDatatableGComponent implements OnInit {
     // const nbSelected = visibles.length;
     const nbSelected = this.dataTableObj[chidrenType].page.count;
     const nb = this.dataTableObj[chidrenType].page.total;
-    return nb == nbSelected ? `(${nb})` : `(${nbSelected}/${nb})`;
+    return (nb == nbSelected) ? `(${nb})` : nb ? `(${nbSelected}/${nb})` : `(${nbSelected})`;
   }
 
   onSortEvent($event) {

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -173,7 +173,7 @@ export class MonitoringDatatableGComponent implements OnInit {
     // const nbSelected = visibles.length;
     const nbSelected = this.dataTableObj[chidrenType].page.count;
     const nb = this.dataTableObj[chidrenType].page.total;
-    return (nb == nbSelected) ? `(${nb})` : nb ? `(${nbSelected}/${nb})` : `(${nbSelected})`;
+    return nb == nbSelected ? `(${nb})` : nb ? `(${nbSelected}/${nb})` : `(${nbSelected})`;
   }
 
   onSortEvent($event) {

--- a/frontend/app/components/monitoring-map-list/monitoring-map-list.component.html
+++ b/frontend/app/components/monitoring-map-list/monitoring-map-list.component.html
@@ -15,8 +15,17 @@
     </pnx-map>
   </div>
   <div id="monitoring-elem-container" class="cadre scroll">
-    <pnx-monitoring-breadcrumbs></pnx-monitoring-breadcrumbs>
+    <div *ngIf="moduleCode !== 'generic'; else staticBreadcrumb">
+      <pnx-monitoring-breadcrumbs *ngIf="obj && obj.bIsInitialized" [obj]="obj"
+        [(bEdit)]="bEdit">
+      </pnx-monitoring-breadcrumbs>
+    </div>
+  
+    <ng-template #staticBreadcrumb>
+      <pnx-monitoring-breadcrumbs></pnx-monitoring-breadcrumbs>
+    </ng-template>
+    
     <!-- <button (click)="displayMap = !displayMap">HIDE MAP</button> -->
-    <router-outlet (activate)="onActivate($event)"></router-outlet>
+    <router-outlet (activate)="onActivate()"></router-outlet>
   </div>
 </div>

--- a/frontend/app/components/monitoring-map-list/monitoring-map-list.component.ts
+++ b/frontend/app/components/monitoring-map-list/monitoring-map-list.component.ts
@@ -7,6 +7,7 @@ import { ConfigJsonService } from '../../services/config-json.service';
 import { ObjectService } from '../../services/object.service';
 import { CommonService } from '@geonature_common/service/common.service';
 import { FormGroup } from '@angular/forms';
+import { Router, NavigationStart, ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'monitoring-map-list.component',
@@ -23,11 +24,18 @@ export class MonitoringMapListComponent {
   displayMap: boolean = true;
   siteSiteGroup: SiteSiteGroup | null = null;
   apiService: ApiGeomService;
+  moduleCode: string;
 
   constructor(
     private _formService: FormService,
-    private _commonService: CommonService
+    private _commonService: CommonService,
+    private _router: Router,
+    private _Activatedroute: ActivatedRoute
   ) {}
+
+  ngOnInit() {
+    this.moduleCode = this._Activatedroute.snapshot.params.moduleCode;
+  }
 
   ngAfterViewInit() {
     const container = document.getElementById('object');
@@ -38,7 +46,16 @@ export class MonitoringMapListComponent {
     });
   }
 
-  onActivate(component) {
+  onActivate() {
+    this._router.events.subscribe((route) => {
+      if (route instanceof NavigationStart) {
+        this._formService.changeFormMapObj({
+          frmGp: null,
+          bEdit: false,
+          obj: null,
+        });
+      }
+    });
     this._formService.currentFormMap
       .pipe(distinctUntilChanged((prev, curr) => prev.obj === curr.obj))
       .subscribe((formMapObj) => {

--- a/frontend/app/components/monitoring-map-list/monitoring-map-list.component.ts
+++ b/frontend/app/components/monitoring-map-list/monitoring-map-list.component.ts
@@ -51,7 +51,6 @@ export class MonitoringMapListComponent {
       if (route instanceof NavigationStart) {
         this._formService.changeFormMapObj({
           frmGp: null,
-          bEdit: false,
           obj: null,
         });
       }

--- a/frontend/app/components/monitoring-sites-create/monitoring-sites-create.component.ts
+++ b/frontend/app/components/monitoring-sites-create/monitoring-sites-create.component.ts
@@ -5,15 +5,15 @@ import { Observable, of } from 'rxjs';
 import { mergeMap, concatMap, tap } from 'rxjs/operators';
 
 import { endPoints } from '../../enum/endpoints';
-import { ISite, ISiteType } from '../../interfaces/geom';
-import { IobjObs, ObjDataType, SiteSiteGroup } from '../../interfaces/objObs';
+import { ISite, ISitesGroup, ISiteType } from '../../interfaces/geom';
+import { IobjObs, ObjDataType } from '../../interfaces/objObs';
 import { SitesGroupService, SitesService } from '../../services/api-geom.service';
 import { FormService } from '../../services/form.service';
 import { ObjectService } from '../../services/object.service';
 import { JsonData } from '../../types/jsondata';
 import { IPaginated } from '../../interfaces/page';
 import { IBreadCrumb } from '../../interfaces/object';
-import { breadCrumbElementBase } from '../breadcrumbs/breadcrumbs.component';
+import { breadCrumbBase } from '../../class/breadCrumb';
 import { GeoJSONService } from '../../services/geojson.service';
 import { AuthService, User } from '@geonature/components/auth/auth.service';
 
@@ -40,12 +40,14 @@ export class MonitoringSitesCreateComponent implements OnInit {
   urlRelative: string;
 
   breadCrumbList: IBreadCrumb[] = [];
-  breadCrumbElemnt: IBreadCrumb = { label: 'Groupe de site', description: '' };
-  breadCrumbElementBase: IBreadCrumb = breadCrumbElementBase;
+  breadCrumbElementBase: IBreadCrumb = breadCrumbBase.baseBreadCrumbSites.value;
 
   obj: MonitoringObject;
   bEdit: boolean = true;
   currentUser: User;
+  moduleCode: string;
+  sitesGroup: ISitesGroup;
+
   constructor(
     private _auth: AuthService,
     private _formService: FormService,
@@ -60,15 +62,21 @@ export class MonitoringSitesCreateComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    const idSitesGroup = this._route.snapshot.data.createSite.id_sites_group;
+    this.moduleCode = this._route.snapshot.data.createSite.moduleCode;
     this.bEdit = true;
     this.objForm = this._formBuilder.group({});
-
     const elements = document.getElementsByClassName('monitoring-map-container');
     if (elements.length >= 1) {
       elements[0].remove();
     }
 
-    this.obj = new MonitoringObject('generic', 'site', null, this._monitoringObjServiceMonitoring);
+    this.obj = new MonitoringObject(
+      this.moduleCode,
+      'site',
+      null,
+      this._monitoringObjServiceMonitoring
+    );
     this.currentUser = this._auth.getCurrentUser();
 
     this._route.paramMap
@@ -78,15 +86,20 @@ export class MonitoringSitesCreateComponent implements OnInit {
         }),
         mergeMap(() => {
           return this.obj.get(0);
+        }),
+        mergeMap(() => {
+          return this._sitesGroupService.getById(idSitesGroup);
         })
       )
-      .subscribe((params) => {
+      .subscribe((sitesGroup) => {
+        this.sitesGroup = sitesGroup;
         this.obj.initTemplate();
         this._formService.changeFormMapObj({
           frmGp: this.objForm,
           obj: this.obj,
         });
         this._formService.changeCurrentEditMode(this.bEdit);
+        this.updateBreadCrumb();
         this.obj.bIsInitialized = true;
       });
   }
@@ -96,7 +109,7 @@ export class MonitoringSitesCreateComponent implements OnInit {
   }
 
   initConfig(): Observable<any> {
-    return this._configService.init().pipe(
+    return this._configService.init(this.moduleCode).pipe(
       concatMap(() => {
         if (this.obj.objectType == 'site' && this.obj.id != null) {
           return this._monitoringObjServiceMonitoring
@@ -119,18 +132,32 @@ export class MonitoringSitesCreateComponent implements OnInit {
     );
   }
 
-  updateBreadCrumb(sitesGroup) {
-    this.breadCrumbElemnt.description = sitesGroup.sites_group_name;
-    this.breadCrumbElemnt.label = 'Groupe de site';
-    this.breadCrumbElemnt['id'] = sitesGroup.id_sites_group;
-    this.breadCrumbElemnt['objectType'] =
-      this._sitesGroupService.objectObs.objectType || 'sites_group';
-    this.breadCrumbElemnt['url'] = [
-      this.breadCrumbElementBase.url,
-      this.breadCrumbElemnt.id?.toString(),
-    ].join('/');
+  updateBreadCrumb() {
+    const breadcrumb: IBreadCrumb[] = [];
 
-    this.breadCrumbList = [this.breadCrumbElementBase, this.breadCrumbElemnt];
+    if (this.moduleCode !== 'generic') {
+      const module = this._configService.config()[this.moduleCode].module;
+      breadcrumb.push({
+        description: module.module_label,
+        label: '',
+        url: `object/${module.module_code}/sites_group`,
+      });
+      if (this.sitesGroup) {
+        breadcrumb.push({
+          description: `Groupe de site : ${this.sitesGroup.sites_group_name}`,
+          label: '',
+          url: `object/${module.module_code}/sites_group/${this.sitesGroup.id_sites_group}`,
+        });
+      }
+    }
+
+    this.breadCrumbElementBase = {
+      ...this.breadCrumbElementBase,
+      url: `object/${this.moduleCode}/site`,
+    };
+
+    this.breadCrumbList = [...breadcrumb, this.breadCrumbElementBase];
+
     this._objService.changeBreadCrumb(this.breadCrumbList, true);
   }
 

--- a/frontend/app/components/monitoring-sites-create/monitoring-sites-create.component.ts
+++ b/frontend/app/components/monitoring-sites-create/monitoring-sites-create.component.ts
@@ -86,7 +86,7 @@ export class MonitoringSitesCreateComponent implements OnInit {
         }),
         mergeMap(() => {
           return this.obj.get(0);
-        }),
+        })
       )
       .subscribe(() => {
         this.obj.initTemplate();

--- a/frontend/app/components/monitoring-sites-create/monitoring-sites-create.component.ts
+++ b/frontend/app/components/monitoring-sites-create/monitoring-sites-create.component.ts
@@ -87,12 +87,8 @@ export class MonitoringSitesCreateComponent implements OnInit {
         mergeMap(() => {
           return this.obj.get(0);
         }),
-        mergeMap(() => {
-          return this._sitesGroupService.getById(idSitesGroup);
-        })
       )
-      .subscribe((sitesGroup) => {
-        this.sitesGroup = sitesGroup;
+      .subscribe(() => {
         this.obj.initTemplate();
         this._formService.changeFormMapObj({
           frmGp: this.objForm,

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.html
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.html
@@ -11,18 +11,16 @@
   [apiService]="siteService"
   [isExtraForm]="true"
   [currentUser]="currentUser"
-  (bEditChange)="onbEditChange($event)" 
-> 
+  (bEditChange)="onbEditChange($event)"
+>
 </pnx-monitoring-form>
-<pnx-monitoring-properties-g
-  *ngIf="!bEdit"
+<pnx-monitoring-properties
+  *ngIf="obj && !bEdit && obj.bIsInitialized"
+  id="nav-properties"
+  [obj]="obj"
   [(bEdit)]="bEdit"
-  [newParentType]="objParent"
-  [selectedObj]="objResolvedProperties"
-  [selectedObjRaw]="objSelected"
-  [permission]="currentPermission"
-  (bEditChange)="onbEditChange($event)" 
-></pnx-monitoring-properties-g>
+  [currentUser]="currentUser"
+></pnx-monitoring-properties>
 <pnx-monitoring-datatable-g
   *ngIf="!bEdit"
   [dataTableArray]="dataTableArray"
@@ -48,5 +46,5 @@
     [optionList]="modules"
     (onDeployed)="getModules()"
     (onSaved)="addNewVisit($event)"
-  ></option-list-btn
-></pnx-monitoring-datatable-g>
+  ></option-list-btn>
+</pnx-monitoring-datatable-g>

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -226,7 +226,6 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
         if (this.moduleCode !== 'generic') {
           this._formService.changeFormMapObj({
             frmGp: null,
-            bEdit: false,
             obj: this.obj,
           });
         }

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -75,7 +75,9 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   currentUser: User;
   currentPermission: TPermission;
 
-  obj: MonitoringObject;
+  obj;
+
+  moduleCode: string;
 
   constructor(
     private _auth: AuthService,
@@ -101,6 +103,10 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   }
 
   ngOnInit() {
+    this.moduleCode = this._Activatedroute.snapshot.data.detailSites.moduleCode;
+    this.siteService.setModuleCode(`${this.moduleCode}`);
+    this._visits_service.setModuleCode(`${this.moduleCode}`);
+
     this.currentUser = this._auth.getCurrentUser();
     this.funcInitValues = this.initValueToSend.bind(this);
     this.funcToFilt = this.partialfuncToFilt.bind(this);
@@ -108,7 +114,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
     this._objService.changeObjectTypeParent(this.siteService.objectObs);
     this._objService.changeObjectType(this._visits_service.objectObs);
 
-    this._configService.init().subscribe(() => {
+    this._configService.init(this.moduleCode).subscribe(() => {
       this.initSiteVisit();
     });
   }
@@ -134,7 +140,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
               this.parentsPath =
                 this._Activatedroute.snapshot.queryParamMap.getAll('parents_path') || [];
               this.obj = new MonitoringObject(
-                'generic',
+                this.moduleCode,
                 'site',
                 params['id'],
                 this._monitoringObjServiceMonitoring
@@ -215,6 +221,15 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
         )
       )
       .subscribe((data) => {
+        this.obj.initTemplate();
+        this.obj.bIsInitialized = true;
+        if (this.moduleCode !== 'generic') {
+          this._formService.changeFormMapObj({
+            frmGp: null,
+            bEdit: false,
+            obj: this.obj,
+          });
+        }
         this._objService.changeSelectedObj(data.site, true);
         this.site = data.site;
         this.types_site = data.site['types_site'];
@@ -259,7 +274,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
 
   onEachFeatureSite() {
     return (feature, layer) => {
-      const popup = this._popup.setSitePopup('generic', feature, {});
+      const popup = this._popup.setSitePopup(this.moduleCode, feature, {});
       layer.bindPopup(popup);
     };
   }
@@ -289,12 +304,16 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   }
 
   getModules() {
-    this.siteService.getSiteModules(this.site.id_base_site).subscribe(
-      (data: Module[]) =>
-        (this.modules = data.map((item) => {
-          return { id: item.module_code, label: item.module_label };
-        }))
-    );
+    if (this.moduleCode === 'generic') {
+      this.siteService.getSiteModules(this.site.id_base_site).subscribe(
+        (data: Module[]) =>
+          (this.modules = data.map((item) => {
+            return { id: item.module_code, label: item.module_label };
+          }))
+      );
+    } else {
+      this.addNewVisit({ id: this.moduleCode, label: '' });
+    }
   }
 
   addNewVisit($event: SelectObject) {
@@ -402,11 +421,32 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
     this.breadCrumbChild['url'] = [
       this.breadCrumbElementBase.url,
       this.breadCrumbParent.id?.toString(),
-      'object/generic/site',
+      `object/${this.moduleCode}/site`,
       this.breadCrumbChild.id?.toString(),
     ].join('/');
 
-    this.breadCrumbList = [this.breadCrumbElementBase, this.breadCrumbParent, this.breadCrumbChild];
+    this.breadCrumbElementBase = {
+      ...this.breadCrumbElementBase,
+      url: `object/${this.moduleCode}/site`,
+    };
+
+    const breadcrumb: IBreadCrumb[] = [];
+
+    if (this.moduleCode !== 'generic') {
+      const module = this._configService.config()[this.moduleCode].module;
+      breadcrumb.push({
+        description: module.module_label,
+        label: '',
+        url: `object/${module.module_code}/site`,
+      });
+    }
+
+    this.breadCrumbList = [
+      ...breadcrumb,
+      this.breadCrumbElementBase,
+      this.breadCrumbParent,
+      this.breadCrumbChild,
+    ];
     this._objService.changeBreadCrumb(this.breadCrumbList, true);
   }
 
@@ -416,11 +456,28 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
     this.breadCrumbChild.label = 'Site';
     this.breadCrumbChild['id'] = sites.id_base_site;
     this.breadCrumbChild['objectType'] = this.siteService.objectObs.objectType + 's' || 'sites';
-    this.breadCrumbChild['url'] = ['object/generic/site', this.breadCrumbChild.id?.toString()].join(
-      '/'
-    );
+    this.breadCrumbChild['url'] = [
+      `object/${this.moduleCode}/site`,
+      this.breadCrumbChild.id?.toString(),
+    ].join('/');
 
-    this.breadCrumbList = [this.breadCrumbElementBase, this.breadCrumbChild];
+    this.breadCrumbElementBase = {
+      ...this.breadCrumbElementBase,
+      url: `object/${this.moduleCode}/site`,
+    };
+
+    const breadcrumb: IBreadCrumb[] = [];
+
+    if (this.moduleCode !== 'generic') {
+      const module = this._configService.config()[this.moduleCode].module;
+      breadcrumb.push({
+        description: module.module_label,
+        label: '',
+        url: `object/${module.module_code}/site`,
+      });
+    }
+
+    this.breadCrumbList = [...breadcrumb, this.breadCrumbElementBase, this.breadCrumbChild];
     this._objService.changeBreadCrumb(this.breadCrumbList, true);
   }
 

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -426,7 +426,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
 
     this.breadCrumbElementBase = {
       ...this.breadCrumbElementBase,
-      url: `object/${this.moduleCode}/site`,
+      url: `object/${this.moduleCode}/sites_group`,
     };
 
     const breadcrumb: IBreadCrumb[] = [];

--- a/frontend/app/components/monitoring-sitesgroups-create/monitoring-sitesgroups-create.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups-create/monitoring-sitesgroups-create.component.ts
@@ -13,6 +13,8 @@ import { GeoJSONService } from '../../services/geojson.service';
 import { MonitoringObject } from '../../class/monitoring-object';
 import { MonitoringObjectService } from '../../services/monitoring-object.service';
 import { ConfigService } from '../../services/config.service';
+import { IBreadCrumb } from '../../interfaces/object';
+import { breadCrumbElementBase } from '../breadcrumbs/breadcrumbs.component';
 
 @Component({
   selector: 'monitoring-sitesgroups-create',
@@ -28,6 +30,12 @@ export class MonitoringSitesGroupsCreateComponent implements OnInit {
   obj: MonitoringObject;
   bEdit: boolean = true;
 
+  breadCrumbList: IBreadCrumb[] = [];
+  breadCrumbElemnt: IBreadCrumb = { label: 'Groupe de site', description: '' };
+  breadCrumbElementBase: IBreadCrumb = breadCrumbElementBase;
+
+  moduleCode: string;
+
   constructor(
     private _auth: AuthService,
     private _formService: FormService,
@@ -41,6 +49,8 @@ export class MonitoringSitesGroupsCreateComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    this.moduleCode = this._route.snapshot.data.createSitesGroups.moduleCode;
+
     this.bEdit = true;
     this.objForm = this._formBuilder.group({});
 
@@ -50,7 +60,7 @@ export class MonitoringSitesGroupsCreateComponent implements OnInit {
     }
 
     this.obj = new MonitoringObject(
-      'generic',
+      this.moduleCode,
       'sites_group',
       null,
       this._monitoringObjServiceMonitoring
@@ -60,7 +70,7 @@ export class MonitoringSitesGroupsCreateComponent implements OnInit {
     this._route.paramMap
       .pipe(
         mergeMap(() => {
-          return this._configService.init();
+          return this._configService.init(this.moduleCode);
         }),
         mergeMap(() => {
           return this.obj.get(0);
@@ -73,8 +83,31 @@ export class MonitoringSitesGroupsCreateComponent implements OnInit {
           obj: this.obj,
         });
         this._formService.changeCurrentEditMode(this.bEdit);
+        this.updateBreadCrumb();
         this.obj.bIsInitialized = true;
       });
+  }
+
+  updateBreadCrumb() {
+    const breadcrumb: IBreadCrumb[] = [];
+
+    if (this.moduleCode !== 'generic') {
+      const module = this._configService.config()[this.moduleCode].module;
+      breadcrumb.push({
+        description: module.module_label,
+        label: '',
+        url: `object/${module.module_code}/sites_group`,
+      });
+    }
+
+    this.breadCrumbElementBase = {
+      ...this.breadCrumbElementBase,
+      url: `object/${this.moduleCode}/site`,
+    };
+
+    this.breadCrumbList = [...breadcrumb, this.breadCrumbElementBase];
+
+    this._objService.changeBreadCrumb(this.breadCrumbList, true);
   }
 
   ngOnDestroy() {

--- a/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.html
+++ b/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.html
@@ -4,20 +4,15 @@
   >
   <span *ngIf="sitesGroup" class="obj-description"> {{ sitesGroup.sites_group_name }} </span>
 </div>
-<pnx-monitoring-properties-g
-  *ngIf="!bEdit"
+<pnx-monitoring-properties
+  *ngIf="obj && !bEdit && obj.bIsInitialized"
+  id="nav-properties"
+  [obj]="obj"
   [(bEdit)]="bEdit"
-  [selectedObj]="sitesGroup"
-  [newParentType]="objParent"
-  [selectedObjRaw]="sitesGroup"
-  [permission]="currentPermission"
-  (bEditChange)="onbEditChange($event)" 
->
-</pnx-monitoring-properties-g>
-<pnx-monitoring-form [obj]="obj" [objForm]="form" (objChanged)="onObjChanged($event)"
-  *ngIf="bEdit && obj?.bIsInitialized" [(bEdit)]="bEdit"
-  [apiService]="siteService" [isExtraForm]="true" [currentUser]="currentUser"
-  (bEditChange)="onbEditChange($event)" >
+  [currentUser]="currentUser">
+</pnx-monitoring-properties>
+<pnx-monitoring-form [obj]="obj" [objForm]="form" (objChanged)="onObjChanged($event)" *ngIf="bEdit" [(bEdit)]="bEdit"
+  [apiService]="siteService" [isExtraForm]="true" [currentUser]="currentUser">
 </pnx-monitoring-form>
 <pnx-monitoring-datatable-g
   *ngIf="!bEdit"

--- a/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
@@ -150,7 +150,6 @@ export class MonitoringSitesgroupsDetailComponent
                   if (this.moduleCode !== 'generic') {
                     this._formService.changeFormMapObj({
                       frmGp: null,
-                      bEdit: false,
                       obj: this.obj,
                     });
                   }

--- a/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
@@ -67,6 +67,8 @@ export class MonitoringSitesgroupsDetailComponent
 
   obj: MonitoringObject;
 
+  moduleCode: string;
+
   constructor(
     private _auth: AuthService,
     public _sitesGroupService: SitesGroupService,
@@ -89,11 +91,12 @@ export class MonitoringSitesgroupsDetailComponent
   }
 
   ngOnInit() {
+    this.moduleCode = this._Activatedroute.snapshot.data.detailSitesGroups.moduleCode;
     this.currentUser = this._auth.getCurrentUser();
     this.form = this._formBuilder.group({});
     this._objService.changeObjectTypeParent(this._sitesGroupService.objectObs);
     this._objService.changeObjectType(this._siteService.objectObs);
-    this._configService.init().subscribe(() => {
+    this._configService.init(this.moduleCode).subscribe(() => {
       this.initSite();
     });
   }
@@ -118,7 +121,7 @@ export class MonitoringSitesgroupsDetailComponent
               this.siteGroupId = params['id'];
               this.baseFilters = { id_sites_group: this.siteGroupId };
               this.obj = new MonitoringObject(
-                'generic',
+                this.moduleCode,
                 'sites_group',
                 this.siteGroupId,
                 this._monitoringObjServiceMonitoring
@@ -126,6 +129,9 @@ export class MonitoringSitesgroupsDetailComponent
               return this.siteGroupId as number;
             }),
             mergeMap((id: number) => {
+              this._siteService.setModuleCode(`${this.moduleCode}`);
+              this._sitesGroupService.setModuleCode(`${this.moduleCode}`);
+
               return forkJoin({
                 sitesGroup: this._sitesGroupService.getById(id).catch((err) => {
                   if (err.status == 404) {
@@ -139,6 +145,15 @@ export class MonitoringSitesgroupsDetailComponent
                 obj: this.obj.get(0),
               }).pipe(
                 map((data) => {
+                  this.obj.initTemplate();
+                  this.obj.bIsInitialized = true;
+                  if (this.moduleCode !== 'generic') {
+                    this._formService.changeFormMapObj({
+                      frmGp: null,
+                      bEdit: false,
+                      obj: this.obj,
+                    });
+                  }
                   return data;
                 })
               );
@@ -164,7 +179,7 @@ export class MonitoringSitesgroupsDetailComponent
         sites['objConfig'] = data.objObsSite;
         this.sitesGroup['objConfig'] = data.objObsSiteGp;
 
-        this.updateBreadCrumb(data.sitesGroup);
+        this.moduleCode === 'generic' && this.updateBreadCrumb(data.sitesGroup);
         this.setDataTableObj({ sites: sites, sitesGroup: this.sitesGroup });
 
         if (this.checkEditParam) {
@@ -207,7 +222,7 @@ export class MonitoringSitesgroupsDetailComponent
 
   onEachFeatureSite() {
     return (feature, layer) => {
-      const popup = this._popup.setSitePopup('generic', feature, {
+      const popup = this._popup.setSitePopup(this.moduleCode, feature, {
         parents_path: ['module', 'sites_group'],
       });
       layer.bindPopup(popup);
@@ -216,7 +231,7 @@ export class MonitoringSitesgroupsDetailComponent
 
   onEachFeatureGroupSite() {
     return (feature, layer) => {
-      const popup = this._popup.setSiteGroupPopup('generic', feature, {
+      const popup = this._popup.setSiteGroupPopup(this.moduleCode, feature, {
         parents_path: ['module', 'sites_group'],
       });
       layer.bindPopup(popup);
@@ -251,7 +266,7 @@ export class MonitoringSitesgroupsDetailComponent
   seeDetails($event) {
     this._objService.changeSelectedParentObj($event);
     this._objService.changeObjectTypeParent(this._siteService.objectObs);
-    this.router.navigate([`/monitorings/object/generic/site/${$event.id_base_site}`], {
+    this.router.navigate([`/monitorings/object/${this.moduleCode}/site/${$event.id_base_site}`], {
       queryParams: { parents_path: ['module', 'sites_group'] },
     });
   }
@@ -259,7 +274,7 @@ export class MonitoringSitesgroupsDetailComponent
   editChild($event) {
     this._objService.changeSelectedParentObj($event);
     this._objService.changeObjectTypeParent(this._siteService.objectObs);
-    this.router.navigate([`/monitorings/object/generic/site/${$event.id_base_site}`], {
+    this.router.navigate([`/monitorings/object/${this.moduleCode}/site/${$event.id_base_site}`], {
       queryParams: { parents_path: ['module', 'sites_group'] },
     });
   }
@@ -271,7 +286,7 @@ export class MonitoringSitesgroupsDetailComponent
     };
 
     queryParams['id_sites_group'] = this.obj.id;
-    this.router.navigate(['/monitorings/object/generic/', type, 'create'], {
+    this.router.navigate([`/monitorings/object/${this.moduleCode}/`, type, 'create'], {
       queryParams: queryParams,
     });
   }
@@ -318,7 +333,7 @@ export class MonitoringSitesgroupsDetailComponent
       Object.assign(objType, objTemp);
       objTemp[objType] = { columns: {}, rows: [], page: {} };
       let config = this._configJsonService.configModuleObject(
-        data[dataType].objConfig.moduleCode,
+        this.moduleCode,
         data[dataType].objConfig.objectType
       );
       data[dataType].objConfig['config'] = config;

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.html
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.html
@@ -1,6 +1,16 @@
 <!-- IF prefered observable compare to ngOnChanges we can remove rows and colsname-->
 <div>
+  <pnx-monitoring-properties
+    *ngIf="moduleCode !== 'generic' && obj && !bEdit && obj.bIsInitialized"
+    id="nav-properties"
+    [obj]="obj"
+    [(bEdit)]="bEdit"
+    [currentUser]="currentUser">
+  </pnx-monitoring-properties>
+  <pnx-monitoring-form [obj]="obj" [objForm]="objForm" [currentUser]="currentUser" *ngIf="bEdit && obj?.bIsInitialized"
+    [(bEdit)]="bEdit" [addChildren]=false></pnx-monitoring-form>
   <pnx-monitoring-datatable-g
+    *ngIf="!bEdit"
     [dataTableArray]="dataTableArray"
     [dataTableObj]="dataTableObj"
     [rows]="siteResolvedProperties"

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -14,13 +14,27 @@ import { IBreadCrumb, SelectObject } from '../../interfaces/object';
 import { FormService } from '../../services/form.service';
 import { Location } from '@angular/common';
 import { breadCrumbBase } from '../../class/breadCrumb';
-import { takeUntil } from 'rxjs/operators';
 import { Module } from '../../interfaces/module';
-import { ReplaySubject } from 'rxjs';
 import { AuthService, User } from '@geonature/components/auth/auth.service';
 import { TPermission } from '../../types/permission';
+import { MonitoringObject } from '../../class/monitoring-object';
+import { MonitoringObjectService } from '../../services/monitoring-object.service';
+import { ConfigService } from '../../services/config.service';
 
 const LIMIT = 10;
+
+import { Observable, of, forkJoin, ReplaySubject } from 'rxjs';
+import {
+  mergeMap,
+  concatMap,
+  map,
+  tap,
+  take,
+  takeUntil,
+  distinctUntilChanged,
+  catchError,
+  skipWhile,
+} from 'rxjs/operators';
 
 @Component({
   selector: 'monitoring-sitesgroups',
@@ -28,12 +42,11 @@ const LIMIT = 10;
   styleUrls: ['./monitoring-sitesgroups.component.css'],
 })
 export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent implements OnInit {
-  @Input() page: IPage;
-  @Input() sitesGroups: ISitesGroup[];
-  @Input() sitesChild: ISite[];
-  @Input() sitesGroupsSelected: ISitesGroup;
+  page: IPage;
+  sitesGroups: ISitesGroup[];
 
-  @Input() obj;
+  obj;
+
   colsname: {};
   objectType: IobjObs<ISitesGroup>;
   objForm: FormGroup;
@@ -64,6 +77,12 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
   currentUser: User;
   currentPermission: TPermission;
 
+  moduleCode: string;
+
+  bEdit: false;
+
+  shouldHandleGroupSites = true;
+
   constructor(
     private _auth: AuthService,
     private _sites_group_service: SitesGroupService,
@@ -76,7 +95,9 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
     private _Activatedroute: ActivatedRoute, // private _routingService: RoutingService
     private _formService: FormService,
     private _location: Location,
-    private _popup: Popup
+    private _popup: Popup,
+    private _monitoringObjectService: MonitoringObjectService,
+    private _configService: ConfigService
   ) {
     super();
     this.getAllItemsCallback = this.getSitesOrSitesGroups; //[this.getSitesGroups, this.getSites];
@@ -90,23 +111,34 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
   }
 
   initSiteGroup() {
-    this._objService.changeObjectTypeParent(this._sites_group_service.objectObs);
-    this._objService.changeObjectType(this._sites_group_service.objectObs);
-
     this._Activatedroute.data.subscribe(({ data }) => {
-      this.currentUser = this._auth.getCurrentUser();
-      this.currentPermission = data.permission;
-      this.page = {
-        count: data.sitesGroups.data.count,
-        limit: data.sitesGroups.data.limit,
-        page: data.sitesGroups.data.page - 1,
-      };
-      this.sitesGroups = data.sitesGroups.data.items;
-      // this.columns = [data.sitesGroups.data.items, data.sites.data.items]
-      this.colsname = data.sitesGroups.objConfig.dataTable.colNameObj;
+      this.shouldHandleGroupSites = Boolean((this._sites_group_service.objectObs as any).config);
+      const objectObs = this.shouldHandleGroupSites ? this._sites_group_service.objectObs : this._sitesService.objectObs;
+  
+      this._objService.changeObjectTypeParent(objectObs);
+      this._objService.changeObjectType(objectObs);
+
       this.currentRoute = data.route;
+      this.moduleCode = data.moduleCode;
+      this.geojsonService.setModuleCode(`${this.moduleCode}`);
+      this.currentUser = this._auth.getCurrentUser();
+      this.currentUser['moduleCruved'] = this._configService.moduleCruved(this.moduleCode);
+
+      this.currentPermission = data.permission;
+      
+      const currentData =  this.shouldHandleGroupSites ? data.sitesGroups.data : data.sites.data;
+      const currentObjConfig =  this.shouldHandleGroupSites ? data.sitesGroups.objConfig : data.sites.objConfig;
+
+      this.page = {
+        count: currentData.count,
+        limit: currentData.limit,
+        page: currentData.page - 1,
+      };
+      this.sitesGroups = currentData.items;
+      // this.columns = [data.sitesGroups.data.items, data.sites.data.items]
+      this.colsname = currentObjConfig.dataTable.colNameObj;
       if (data.route == 'site') {
-        this.activetabIndex = 1;
+        this.activetabIndex = this.shouldHandleGroupSites ? 1 : 0;
         this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSites.value;
         this.currentPermission.MONITORINGS_SITES.canRead ? this.getGeometriesSite() : null;
       } else {
@@ -115,10 +147,41 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
           ? this.geojsonService.getSitesGroupsGeometries(this.onEachFeatureSiteGroups())
           : null;
       }
-      const { route, permission, ...dataToTable } = data;
+      const { route, permission, moduleCode, ...dataToTable } = data;
 
       this.setDataTableObj(dataToTable);
-      this.updateBreadCrumb();
+
+      if (this.moduleCode !== 'generic') {
+        this.obj = new MonitoringObject(
+          this.moduleCode,
+          'module',
+          null,
+          this._monitoringObjectService
+        );
+      }
+
+      if (this.obj) {
+        return this._configService
+          .init(this.moduleCode)
+          .pipe(
+            mergeMap(() => {
+              return this.obj.get(0);
+            })
+          )
+          .subscribe(() => {
+            this.obj.initTemplate();
+            this.objForm = this._formBuilder.group({});
+            this.obj.bIsInitialized = true;
+            this._formService.changeFormMapObj({
+              frmGp: this.objForm,
+              bEdit: false,
+              obj: this.obj,
+            });
+          });
+      } else {
+        this._configService.init(this.moduleCode);
+        this.updateBreadCrumb();
+      }
     });
   }
 
@@ -131,7 +194,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
 
   onEachFeatureSiteGroups(): Function {
     return (feature, layer) => {
-      const popup = this._popup.setSiteGroupPopup('generic', feature, {});
+      const popup = this._popup.setSiteGroupPopup(this.moduleCode, feature, {});
       layer.bindPopup(popup);
     };
   }
@@ -185,7 +248,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
 
   onEachFeatureSite() {
     return (feature, layer) => {
-      const popup = this._popup.setSitePopup('generic', feature, {});
+      const popup = this._popup.setSitePopup(this.moduleCode, feature, {});
       layer.bindPopup(popup);
     };
   }
@@ -193,21 +256,27 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
   seeDetails($event) {
     // TODO: routerLink
     let objectType;
-    if (this.activetabIndex == 1) {
-      this._objService.changeObjectTypeParent(this._sitesService.objectObs);
-      objectType = 'sites';
-    } else {
-      this._objService.changeObjectTypeParent(this._sites_group_service.objectObs);
-      objectType = 'sites_group';
+    if (this.moduleCode === 'generic') {
+      if (this.activetabIndex == 1) {
+        this._objService.changeObjectTypeParent(this._sitesService.objectObs);
+        objectType = 'sites';
+      } else {
+        this._objService.changeObjectTypeParent(this._sites_group_service.objectObs);
+        objectType = 'sites_group';
+      }
     }
-    this.router.navigate(['/monitorings/object/generic/', this.currentRoute, $event[$event.id]], {
-      queryParams: { parents_path: ['module', objectType] },
-    });
+
+    this.router.navigate(
+      [`/monitorings/object/${this.moduleCode}/`, this.currentRoute, $event[$event.id]],
+      {
+        queryParams: { parents_path: ['module'] },
+      }
+    );
   }
 
   editChild($event) {
     // TODO: routerLink
-    if (this.activetabIndex == 1) {
+    if (this.shouldHandleGroupSites && this.activetabIndex == 1 || !this.shouldHandleGroupSites) {
       this._objService.changeObjectTypeParent(this._sitesService.objectObs);
     } else {
       this._objService.changeObjectTypeParent(this._sites_group_service.objectObs);
@@ -218,7 +287,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       this._sites_group_service.objectObs.endPoint
     );
     this.router.navigate([
-      '/monitorings/object/generic/',
+      `/monitorings/object/${this.moduleCode}/`,
       this.currentRoute,
       $event[$event.id],
       { edit: true },
@@ -233,9 +302,12 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       queryParams[row['pk']] = row['id'];
       queryParams['parents_path'] = ['module', 'sites_group'];
 
-      this.router.navigate(['/monitorings/object/generic/', row['object_type'], 'create'], {
-        queryParams: queryParams,
-      });
+      this.router.navigate(
+        [`/monitorings/object/${this.moduleCode}/`, row['object_type'], 'create'],
+        {
+          queryParams: queryParams,
+        }
+      );
     }
   }
 
@@ -244,7 +316,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
     const queryParams = {
       parents_path: ['module'],
     };
-    this.router.navigate(['/monitorings/object/generic/', type, 'create'], {
+    this.router.navigate([`/monitorings/object/${this.moduleCode}/`, type, 'create'], {
       queryParams: queryParams,
     });
   }
@@ -256,9 +328,12 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
           this.bDeleteModalEmitter.emit(false);
           this.activetabIndex = 0;
           this.currentRoute = 'sites_group';
-          this.router.navigate(['/monitorings/object/generic/sites_group', { delete: true }], {
-            onSameUrlNavigation: 'reload',
-          });
+          this.router.navigate(
+            [`/monitorings/object/${this.moduleCode}/sites_group`, { delete: true }],
+            {
+              onSameUrlNavigation: 'reload',
+            }
+          );
           this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSiteGroups.value;
           this.updateBreadCrumb();
           this.geojsonService.removeFeatureGroup(this.geojsonService.sitesGroupFeatureGroup);
@@ -271,7 +346,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
           this.bDeleteModalEmitter.emit(false);
           this.activetabIndex = 1;
           this.currentRoute = 'site';
-          this.router.navigate(['/monitorings/object/generic/site', { delete: true }], {
+          this.router.navigate([`/monitorings/object/${this.moduleCode}/site`, { delete: true }], {
             onSameUrlNavigation: 'reload',
           });
           this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSites.value;
@@ -301,7 +376,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
     if ($event == 'site') {
       this.activetabIndex = 1;
       this.currentRoute = 'site';
-      this._location.go('/monitorings/object/generic/site');
+      this._location.go(`/monitorings/object/${this.moduleCode}/site`);
       this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSites.value;
       this.updateBreadCrumb();
       this.geojsonService.removeFeatureGroup(this.geojsonService.sitesGroupFeatureGroup);
@@ -309,7 +384,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
     } else {
       this.activetabIndex = 0;
       this.currentRoute = 'sites_group';
-      this._location.go('/monitorings/object/generic/sites_group');
+      this._location.go(`/monitorings/object/${this.moduleCode}/sites_group`);
       this.breadCrumbElementBase = breadCrumbBase.baseBreadCrumbSiteGroups.value;
       this.updateBreadCrumb();
       this.geojsonService.removeFeatureGroup(this.geojsonService.sitesFeatureGroup);
@@ -322,6 +397,9 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
   setDataTableObj(data) {
     const objTemp = {};
     for (const dataType in data) {
+      if (!data[dataType].objConfig) {
+        continue;
+      }
       let objType = data[dataType].objConfig.objectType;
       Object.assign(objType, objTemp);
       objTemp[objType] = { columns: {}, rows: [], page: {} };
@@ -334,6 +412,9 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
     }
 
     for (const dataType in data) {
+      if (!data[dataType].objConfig) {
+        continue;
+      }
       let objType = data[dataType].objConfig.objectType;
       objTemp[objType].columns = data[dataType].objConfig.dataTable.colNameObj;
       if (objType == 'site') {
@@ -360,7 +441,11 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
   addChildrenVisit(event) {
     if (event.objectType == 'site') {
       this.siteSelectedId = event.rowSelected[event.rowSelected['pk']];
-      this.getModules();
+      if (this.moduleCode === 'generic') {
+        this.getModules();
+      } else {
+        this.addNewVisit({ id: this.moduleCode, label: '' });
+      }
     }
   }
 
@@ -392,5 +477,9 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
         queryParams: { id_base_site: this.siteSelectedId, parents_path: parents_path },
       });
     });
+  }
+
+  initConfig(): Observable<any> {
+    return this._configService.init(this.obj.moduleCode);
   }
 }

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -111,7 +111,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
 
   initSiteGroup() {
     this._Activatedroute.data.subscribe(({ data }) => {
-      this.shouldHandleGroupSites = Boolean((this._sites_group_service.objectObs as any).config);
+      this.shouldHandleGroupSites = Boolean((data.sitesGroups.objConfig as any));
       const objectObs = this.shouldHandleGroupSites ? this._sites_group_service.objectObs : this._sitesService.objectObs;
   
       this._objService.changeObjectTypeParent(objectObs);
@@ -127,7 +127,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       
       const currentData =  this.shouldHandleGroupSites ? data.sitesGroups.data : data.sites.data;
       const currentObjConfig =  this.shouldHandleGroupSites ? data.sitesGroups.objConfig : data.sites.objConfig;
-      // 
+      
       this.page = {
         count: currentData.count,
         limit: currentData.limit,

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -174,7 +174,6 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
             this.obj.bIsInitialized = true;
             this._formService.changeFormMapObj({
               frmGp: this.objForm,
-              bEdit: false,
               obj: this.obj,
             });
           });

--- a/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups/monitoring-sitesgroups.component.ts
@@ -27,11 +27,7 @@ import { resolveProperty } from '../../utils/utils';
 const LIMIT = 10;
 
 import { Observable, ReplaySubject, forkJoin, of } from 'rxjs';
-import {
-  map,
-  mergeMap,
-  takeUntil,
-} from 'rxjs/operators';
+import { map, mergeMap, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'monitoring-sitesgroups',
@@ -111,9 +107,11 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
 
   initSiteGroup() {
     this._Activatedroute.data.subscribe(({ data }) => {
-      this.shouldHandleGroupSites = Boolean((data.sitesGroups.objConfig as any));
-      const objectObs = this.shouldHandleGroupSites ? this._sites_group_service.objectObs : this._sitesService.objectObs;
-  
+      this.shouldHandleGroupSites = Boolean(data.sitesGroups.objConfig as any);
+      const objectObs = this.shouldHandleGroupSites
+        ? this._sites_group_service.objectObs
+        : this._sitesService.objectObs;
+
       this._objService.changeObjectTypeParent(objectObs);
       this._objService.changeObjectType(objectObs);
 
@@ -124,10 +122,12 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
       this.currentUser['moduleCruved'] = this._configService.moduleCruved(this.moduleCode);
 
       this.currentPermission = data.permission;
-      
-      const currentData =  this.shouldHandleGroupSites ? data.sitesGroups.data : data.sites.data;
-      const currentObjConfig =  this.shouldHandleGroupSites ? data.sitesGroups.objConfig : data.sites.objConfig;
-      
+
+      const currentData = this.shouldHandleGroupSites ? data.sitesGroups.data : data.sites.data;
+      const currentObjConfig = this.shouldHandleGroupSites
+        ? data.sitesGroups.objConfig
+        : data.sites.objConfig;
+
       this.page = {
         count: currentData.count,
         limit: currentData.limit,
@@ -220,7 +220,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
             !specificConfig ||
             Object.keys(specificConfig).length === 0
           ) {
-            return of(paginatedSiteGroups); 
+            return of(paginatedSiteGroups);
           }
 
           const siteGroupProcessingObservables = siteGroupsItems.map((siteGroupItem) => {
@@ -231,9 +231,9 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
                   this._monitoringObjectService,
                   this._cacheService,
                   this._configService,
-                  this.moduleCode, 
-                  specificConfig[attribut_name], 
-                  siteGroupItem[attribut_name] 
+                  this.moduleCode,
+                  specificConfig[attribut_name],
+                  siteGroupItem[attribut_name]
                 );
               }
             }
@@ -254,7 +254,10 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
           });
 
           return forkJoin(siteGroupProcessingObservables).pipe(
-            map((resolvedSiteGroupItems) => ({ ...paginatedSiteGroups, items: resolvedSiteGroupItems }))
+            map((resolvedSiteGroupItems) => ({
+              ...paginatedSiteGroups,
+              items: resolvedSiteGroupItems,
+            }))
           );
         }),
         takeUntil(this.destroyed$)
@@ -269,7 +272,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
         this.rows = processedPaginatedData.items;
         this.colsname = this._sites_group_service.objectObs.dataTable.colNameObj;
         this.dataTableObj.sites_group.rows = processedPaginatedData.items;
-        this.dataTableObj.sites_group.page = { 
+        this.dataTableObj.sites_group.page = {
           count: processedPaginatedData.count,
           limit: processedPaginatedData.limit,
           page: processedPaginatedData.page - 1,
@@ -286,7 +289,12 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
           const sites = paginatedSites.items;
           const specificConfig = this.config?.specific;
 
-          if (!sites || sites.length === 0 || !specificConfig || Object.keys(specificConfig).length === 0) {
+          if (
+            !sites ||
+            sites.length === 0 ||
+            !specificConfig ||
+            Object.keys(specificConfig).length === 0
+          ) {
             return of(paginatedSites);
           }
 
@@ -375,7 +383,7 @@ export class MonitoringSitesGroupsComponent extends MonitoringGeomComponent impl
 
   editChild($event) {
     // TODO: routerLink
-    if (this.shouldHandleGroupSites && this.activetabIndex == 1 || !this.shouldHandleGroupSites) {
+    if ((this.shouldHandleGroupSites && this.activetabIndex == 1) || !this.shouldHandleGroupSites) {
       this._objService.changeObjectTypeParent(this._sitesService.objectObs);
     } else {
       this._objService.changeObjectTypeParent(this._sites_group_service.objectObs);

--- a/frontend/app/gnModule.module.ts
+++ b/frontend/app/gnModule.module.ts
@@ -56,59 +56,43 @@ import { BtnSelectComponent } from './components/btn-select/btn-select.component
 import { MonitoringSitesDetailComponent } from './components/monitoring-sites-detail/monitoring-sites-detail.component';
 import { OptionListButtonComponent } from './components/option-list-btn/option-list-btn.component';
 import { MatErrorMessagesDirective } from './utils/matErrorMessages.directive';
-import { SitesGroupsReslver } from './resolver/sites-groups.resolver';
+import { SitesGroupsResolver } from './resolver/sites-groups.resolver';
 import { CreateSiteResolver } from './resolver/create-site.resolver';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 import { ObjectsPermissionMonitorings } from './enum/objectPermission';
 
 import { Popup } from './utils/popup';
 import { ListService } from './services/list.service';
+import { CreateSitesGroupsResolver } from './resolver/create-sites-groups-resolver';
+import { DetailSitesGroupsResolver } from './resolver/detail-sites-groups-resolver';
+import { DetailSitesResolver } from './resolver/detail-sites-resolver';
+import { MapListResolver } from './resolver/map-list-resolver';
 
 // my module routing
 const routes: Routes = [
   /** modules  */
   { path: '', component: ModulesComponent },
   {
-    path: 'object/generic/site',
+    path: 'object/:moduleCode/sites_group',
     component: MonitoringMapListComponent,
+    resolve: {
+      data: MapListResolver,
+    },
     children: [
       {
         path: '',
         component: MonitoringSitesGroupsComponent,
         resolve: {
-          data: SitesGroupsReslver,
-        },
-        runGuardsAndResolvers: 'always',
-      },
-      {
-        path: 'create',
-        component: MonitoringSitesCreateComponent,
-        resolve: {
-          data: CreateSiteResolver,
-        },
-      },
-      {
-        path: ':id',
-        component: MonitoringSitesDetailComponent,
-      },
-    ],
-  },
-
-  {
-    path: 'object/generic/sites_group',
-    component: MonitoringMapListComponent,
-    children: [
-      {
-        path: '',
-        component: MonitoringSitesGroupsComponent,
-        resolve: {
-          data: SitesGroupsReslver,
+          data: SitesGroupsResolver,
         },
         runGuardsAndResolvers: 'always',
       },
       {
         path: 'create',
         component: MonitoringSitesGroupsCreateComponent,
+        resolve: {
+          createSitesGroups: CreateSitesGroupsResolver,
+        },
       },
       {
         path: ':id',
@@ -116,33 +100,63 @@ const routes: Routes = [
           {
             path: '',
             component: MonitoringSitesgroupsDetailComponent,
+            resolve: {
+              detailSitesGroups: DetailSitesGroupsResolver,
+            },
           },
           {
             path: 'create',
             component: MonitoringSitesCreateComponent,
             resolve: {
-              data: CreateSiteResolver,
+              createSite: CreateSiteResolver,
             },
           },
           {
             path: 'site/:id',
             component: MonitoringSitesDetailComponent,
+            resolve: {
+              detailSites: DetailSitesResolver,
+            },
           },
         ],
       },
     ],
   },
-  /** module  */
-  { path: 'module/:moduleCode', component: MonitoringObjectComponent },
-  /** create module */
-  { path: 'module', component: MonitoringObjectComponent },
-
-  /** object */
+  {
+    path: 'object/:moduleCode/site',
+    component: MonitoringMapListComponent,
+    resolve: {
+      data: MapListResolver,
+    },
+    children: [
+      {
+        path: '',
+        component: MonitoringSitesGroupsComponent,
+        resolve: {
+          data: SitesGroupsResolver,
+        },
+        runGuardsAndResolvers: 'always',
+      },
+      {
+        path: 'create',
+        component: MonitoringSitesCreateComponent,
+        resolve: {
+          createSite: CreateSiteResolver,
+        },
+      },
+      {
+        path: ':id',
+        component: MonitoringSitesDetailComponent,
+        resolve: {
+          detailSites: DetailSitesResolver,
+        },
+      },
+    ],
+  },
   {
     path: 'object/:moduleCode/:objectType/:id',
     component: MonitoringObjectComponent,
   },
-  /** create object */
   {
     path: 'create_object/:moduleCode/:objectType',
     component: MonitoringObjectComponent,
@@ -209,8 +223,9 @@ const routes: Routes = [
     ObjectService,
     ApiGeomService,
     VisitsService,
-    SitesGroupsReslver,
+    SitesGroupsResolver,
     CreateSiteResolver,
+    CreateSitesGroupsResolver,
     PermissionService,
     Popup,
   ],

--- a/frontend/app/resolver/create-site.resolver.ts
+++ b/frontend/app/resolver/create-site.resolver.ts
@@ -1,24 +1,14 @@
 import { Injectable } from '@angular/core';
-import { SitesGroupService } from '../services/api-geom.service';
-import { Observable, of } from 'rxjs';
-import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
-import { ISitesGroup } from '../interfaces/geom';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
-export class CreateSiteResolver implements Resolve<ISitesGroup | null> {
-  constructor(public service: SitesGroupService) {}
+export class CreateSiteResolver implements Resolve<{ moduleCode: string; id_sites_group: string }> {
+  constructor() {}
 
-  resolve(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ): Observable<ISitesGroup | null> {
-    const siteGroupId = parseInt(route.paramMap.get('id'));
-    let $getSiteGroups: Observable<ISitesGroup | null>;
-    isNaN(siteGroupId)
-      ? ($getSiteGroups = of(null))
-      : ($getSiteGroups = this.service.getById(siteGroupId).pipe((result) => {
-          return result;
-        }));
-    return $getSiteGroups;
+  resolve(route: ActivatedRouteSnapshot): { moduleCode: string; id_sites_group: string } {
+    return {
+      moduleCode: route.parent.params.moduleCode ?? route.parent.parent.params.moduleCode,
+      id_sites_group: route.queryParams.id_sites_group,
+    };
   }
 }

--- a/frontend/app/resolver/create-sites-groups-resolver.ts
+++ b/frontend/app/resolver/create-sites-groups-resolver.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class CreateSitesGroupsResolver implements Resolve<{ moduleCode: string }> {
+  constructor() {}
+
+  resolve(route: ActivatedRouteSnapshot): { moduleCode: string } {
+    return { moduleCode: route.parent.params.moduleCode };
+  }
+}

--- a/frontend/app/resolver/detail-sites-groups-resolver.ts
+++ b/frontend/app/resolver/detail-sites-groups-resolver.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class DetailSitesGroupsResolver implements Resolve<{ moduleCode: string }> {
+  constructor() {}
+
+  resolve(route: ActivatedRouteSnapshot): { moduleCode: string } {
+    return { moduleCode: route.parent.parent.params.moduleCode };
+  }
+}

--- a/frontend/app/resolver/detail-sites-resolver.ts
+++ b/frontend/app/resolver/detail-sites-resolver.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class DetailSitesResolver implements Resolve<{ moduleCode: string }> {
+  constructor() {}
+
+  resolve(route: ActivatedRouteSnapshot): { moduleCode: string } {
+    return { moduleCode: route.parent.params.moduleCode ?? route.parent.parent.params.moduleCode };
+  }
+}

--- a/frontend/app/resolver/map-list-resolver.ts
+++ b/frontend/app/resolver/map-list-resolver.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+@Injectable({ providedIn: 'root' })
+export class MapListResolver implements Resolve<{ moduleCode: string }> {
+  constructor() {}
+
+  resolve(route: ActivatedRouteSnapshot): { moduleCode: string } {
+    return { moduleCode: route.params.moduleCode };
+  }
+}

--- a/frontend/app/resolver/sites-groups.resolver.ts
+++ b/frontend/app/resolver/sites-groups.resolver.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { SitesGroupService, SitesService } from '../services/api-geom.service';
 import { Observable, forkJoin, of } from 'rxjs';
-import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot,Router } from '@angular/router';
 import { ISite, ISitesGroup } from '../interfaces/geom';
 import { IPaginated } from '../interfaces/page';
 import { IobjObs } from '../interfaces/objObs';
@@ -10,15 +10,17 @@ import { ConfigJsonService } from '../services/config-json.service';
 import { PermissionService } from '../services/permission.service';
 import { TPermission } from '../types/permission';
 import { DataMonitoringObjectService } from '../services/data-monitoring-object.service';
+
 const LIMIT = 10;
 
 @Injectable({ providedIn: 'root' })
-export class SitesGroupsReslver
+export class SitesGroupsResolver
   implements
     Resolve<{
       sitesGroups: { data: IPaginated<ISitesGroup>; objConfig: IobjObs<ISitesGroup> };
       sites: { data: IPaginated<ISite>; objConfig: IobjObs<ISite> };
       route: string;
+      moduleCode: string | null;
     }>
 {
   currentPermission: TPermission;
@@ -28,7 +30,8 @@ export class SitesGroupsReslver
     public serviceSite: SitesService,
     public _configJsonService: ConfigJsonService,
     public _permissionService: PermissionService,
-    private _dataMonitoringObjectService: DataMonitoringObjectService
+    private _dataMonitoringObjectService: DataMonitoringObjectService,
+    private router: Router
   ) {}
 
   resolve(
@@ -38,53 +41,60 @@ export class SitesGroupsReslver
     sitesGroups: { data: IPaginated<ISitesGroup>; objConfig: IobjObs<ISitesGroup> };
     sites: { data: IPaginated<ISite>; objConfig: IobjObs<ISite> };
     route: string;
+    moduleCode: string | null;
   }> {
+    const moduleCode = route.params.moduleCode || 'generic';
+    this.service.setModuleCode(`${moduleCode}`);
+    this.serviceSite.setModuleCode(`${moduleCode}`);
+
     const $getPermissionMonitoring = this._dataMonitoringObjectService.getCruvedMonitoring();
     const $permissionUserObject = this._permissionService.currentPermissionObj;
     const $configSitesGroups = this.service.initConfig();
     const $configSites = this.serviceSite.initConfig();
-
     const resolvedData = $getPermissionMonitoring.pipe(
       map((listObjectCruved: Object) => {
         this._permissionService.setPermissionMonitorings(listObjectCruved);
       }),
       concatMap(() =>
         $permissionUserObject.pipe(
-          map((permissionObject: TPermission) => (this.currentPermission = permissionObject))
+          map((permissionObject: TPermission) => (this.currentPermission = permissionObject)),
         )
       ),
       concatMap(() =>
         forkJoin([$configSitesGroups, $configSites]).pipe(
           map((configs) => {
-            const configSchemaSiteGroup = this._configJsonService.configModuleObject(
+            if (!configs[0] && state.url.includes("/monitorings/object/") && state.url.includes("sites_group") ) {
+              this.router.navigate(['monitorings', 'object', route.params.moduleCode, 'site']);
+            }
+            
+            const configSchemaSiteGroup = configs[0] ? this._configJsonService.configModuleObject(
               configs[0].moduleCode,
               configs[0].objectType
-            );
+            ) : null;
 
-            const configSchemaSite = this._configJsonService.configModuleObject(
+            const configSchemaSite = configs[1] ? this._configJsonService.configModuleObject(
               configs[1].moduleCode,
               configs[1].objectType
-            );
+            ) : null;
 
-            const sortSiteGroupInit =
+            const sortSiteGroupInit = configSchemaSiteGroup ?
               'sorts' in configSchemaSiteGroup
                 ? {
                     sort_dir: configSchemaSiteGroup.sorts[0].dir,
                     sort: configSchemaSiteGroup.sorts[0].prop,
                   }
-                : {};
-            const sortSiteInit =
+                : {} : null;
+            const sortSiteInit = configSchemaSite ?
               'sorts' in configSchemaSite
                 ? { sort_dir: configSchemaSite.sorts[0].dir, sort: configSchemaSite.sorts[0].prop }
-                : {};
+                : {} : null;
 
-            const $getSiteGroups = this.currentPermission.MONITORINGS_GRP_SITES.canRead
+            const $getSiteGroups = sortSiteGroupInit ? this.currentPermission.MONITORINGS_GRP_SITES.canRead
               ? this.service.get(1, LIMIT, sortSiteGroupInit)
-              : of({ items: [], count: 0, limit: 0, page: 1 });
-            // const $getSiteGroups = this.service.get(1, LIMIT, sortSiteGroupInit)
-            const $getSites = this.currentPermission.MONITORINGS_SITES.canRead
+              : of({ items: [], count: 0, limit: 0, page: 1 }) : of(null);
+            const $getSites = sortSiteInit ? this.currentPermission.MONITORINGS_SITES.canRead
               ? this.serviceSite.get(1, LIMIT, sortSiteInit)
-              : of({ items: [], count: 0, limit: 0, page: 1 });
+              : of({ items: [], count: 0, limit: 0, page: 1 }) : of(null);
 
             return forkJoin([$getSiteGroups, $getSites]).pipe(
               map(([siteGroups, sites]) => {
@@ -93,6 +103,7 @@ export class SitesGroupsReslver
                   sites: { data: sites, objConfig: configs[1] },
                   route: route['_urlSegment'].segments[3].path,
                   permission: this.currentPermission,
+                  moduleCode,
                 };
               })
             );

--- a/frontend/app/services/api-geom.service.ts
+++ b/frontend/app/services/api-geom.service.ts
@@ -51,7 +51,7 @@ export class ApiService<T = IObject> implements IService<T> {
           'display_list'
         );
 
-        if(!fieldNamesList) {
+        if (!fieldNamesList) {
           return null;
         }
 
@@ -137,18 +137,14 @@ export class ApiGeomService<T = IGeomObject> extends ApiService<T> implements IG
     const clean_params = Object.fromEntries(
       Object.entries(params).filter(([, v]) => v !== '' && v !== null)
     );
-    
+
     const endPoint = !(this.objectObs.moduleCode === 'generic')
       ? `refacto/${this.objectObs.moduleCode}/${this.endPoint}/geometries`
       : `${this.endPoint}/geometries`;
 
-    return this._cacheService.request<Observable<GeoJSON.FeatureCollection>>(
-      'get',
-      endPoint,
-      {
-        queryParams: { ...clean_params },
-      }
-    );
+    return this._cacheService.request<Observable<GeoJSON.FeatureCollection>>('get', endPoint, {
+      queryParams: { ...clean_params },
+    });
   }
 
   getConfig(): Observable<T> {

--- a/frontend/app/services/api-geom.service.ts
+++ b/frontend/app/services/api-geom.service.ts
@@ -25,6 +25,7 @@ import { Module } from '../interfaces/module';
 export class ApiService<T = IObject> implements IService<T> {
   public objectObs: IobjObs<T>;
   public endPoint: endPoints;
+
   constructor(
     protected _cacheService: CacheService,
     protected _configJsonService: ConfigJsonService
@@ -49,6 +50,10 @@ export class ApiService<T = IObject> implements IService<T> {
           this.objectObs.objectType,
           'display_list'
         );
+
+        if(!fieldNamesList) {
+          return null;
+        }
 
         const labelList = this._configJsonService.configModuleObjectParam(
           this.objectObs.moduleCode,
@@ -77,15 +82,25 @@ export class ApiService<T = IObject> implements IService<T> {
       })
     );
   }
+
   get(page: number = 1, limit: number = LIMIT, params: JsonData = {}): Observable<IPaginated<T>> {
-    return this._cacheService.request<Observable<IPaginated<T>>>('get', this.objectObs.endPoint, {
-      queryParams: { page, limit, ...params },
-    });
+    const module = !(this.objectObs.moduleCode === 'generic')
+      ? 'refacto/' + this.objectObs.moduleCode + '/'
+      : '';
+
+    return this._cacheService.request<Observable<IPaginated<T>>>(
+      'get',
+      `${module}${this.objectObs.endPoint}`,
+      {
+        queryParams: { page, limit, ...params },
+      }
+    );
   }
 
   getById(id: number): Observable<T> {
     return this._cacheService.request<Observable<T>>('get', `${this.objectObs.endPoint}/${id}`);
   }
+
   patch(id: number, updatedData: IObjectProperties<T>): Observable<T> {
     return this._cacheService.request('patch', `${this.objectObs.endPoint}/${id}`, {
       postData: updatedData as {},
@@ -101,7 +116,12 @@ export class ApiService<T = IObject> implements IService<T> {
   delete(id: number): Observable<T> {
     return this._cacheService.request('delete', `${this.objectObs.endPoint}/${id}`);
   }
+
+  setModuleCode(moduleCode: string) {
+    this.objectObs.moduleCode = moduleCode;
+  }
 }
+
 @Injectable()
 export class ApiGeomService<T = IGeomObject> extends ApiService<T> implements IGeomService<T> {
   constructor(
@@ -117,10 +137,14 @@ export class ApiGeomService<T = IGeomObject> extends ApiService<T> implements IG
     const clean_params = Object.fromEntries(
       Object.entries(params).filter(([, v]) => v !== '' && v !== null)
     );
+    
+    const endPoint = !(this.objectObs.moduleCode === 'generic')
+      ? `refacto/${this.objectObs.moduleCode}/${this.endPoint}/geometries`
+      : `${this.endPoint}/geometries`;
 
     return this._cacheService.request<Observable<GeoJSON.FeatureCollection>>(
       'get',
-      `${this.endPoint}/geometries`,
+      endPoint,
       {
         queryParams: { ...clean_params },
       }
@@ -137,6 +161,7 @@ export class SitesGroupService extends ApiGeomService<ISitesGroup> {
   constructor(_cacheService: CacheService, _configJsonService: ConfigJsonService) {
     super(_cacheService, _configJsonService);
   }
+
   init(): void {
     const endPoint = endPoints.sites_groups;
     const objectObs: IobjObs<ISitesGroup> = {
@@ -171,9 +196,16 @@ export class SitesGroupService extends ApiGeomService<ISitesGroup> {
     limit: number = 10,
     params: JsonData = {}
   ): Observable<IPaginated<ISite>> {
-    return this._cacheService.request<Observable<IPaginated<ISite>>>('get', `sites`, {
-      queryParams: { page, limit, ...params },
-    });
+    const module = !(this.objectObs.moduleCode === 'generic')
+      ? 'refacto/' + this.objectObs.moduleCode + '/'
+      : '';
+    return this._cacheService.request<Observable<IPaginated<ISite>>>(
+      'get',
+      `${module}${endPoints.sites}`,
+      {
+        queryParams: { page, limit, ...params },
+      }
+    );
   }
 }
 

--- a/frontend/app/services/data-table.service.ts
+++ b/frontend/app/services/data-table.service.ts
@@ -38,15 +38,13 @@ export class DataTableService {
   //   this.dataCols.next(allColumn)
   // }
 
-  colsTable(colName: {}, dataTable): IColumn[] {
+  colsTable(colName: {}): IColumn[] {
     const arr = Object.keys(colName);
-    const allColumn: IColumn[] = arr
-      .filter((item) => Object.keys(dataTable).includes(item))
-      .map((elm) => ({
-        name: colName[elm],
-        prop: elm,
-        description: elm,
-      }));
+    const allColumn: IColumn[] = arr.map((elm) => ({
+      name: colName[elm],
+      prop: elm,
+      description: elm,
+    }));
     return allColumn;
   }
 

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -50,6 +50,11 @@ export class GeoJSONService {
     private _formService: FormService
   ) {}
 
+  setModuleCode(moduleCode: string) {
+    this._sites_group_service.setModuleCode(moduleCode)
+    this._sites_service.setModuleCode(moduleCode)
+  }
+
   removeAllLayers() {
     this.removeFeatureGroup(this.sitesGroupFeatureGroup);
     this.removeFeatureGroup(this.sitesFeatureGroup);

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -51,8 +51,8 @@ export class GeoJSONService {
   ) {}
 
   setModuleCode(moduleCode: string) {
-    this._sites_group_service.setModuleCode(moduleCode)
-    this._sites_service.setModuleCode(moduleCode)
+    this._sites_group_service.setModuleCode(moduleCode);
+    this._sites_service.setModuleCode(moduleCode);
   }
 
   removeAllLayers() {

--- a/frontend/app/utils/utils.ts
+++ b/frontend/app/utils/utils.ts
@@ -1,5 +1,5 @@
 import { Observable, forkJoin, of } from 'rxjs';
-import { concatMap,  mergeMap } from 'rxjs/operators';
+import { concatMap, mergeMap } from 'rxjs/operators';
 import { JsonData } from '../types/jsondata';
 
 export class Utils {
@@ -123,62 +123,75 @@ export class Utils {
   }
 }
 
-export function resolveProperty(_objService, _cacheService,_configService, moduleCode, elem, val): Observable<any> {
-    if (elem.type_widget === 'date' || (elem.type_util === 'date' && val)) {
-      val = Utils.formatDate(val);
-    }
-
-    const fieldName = _objService.configUtils(elem, moduleCode);
-
-    if (val && fieldName && elem.type_widget) {
-      return getUtil(_cacheService, elem.type_util, val, fieldName, elem.value_field_name);
-    }
-    return of(val);
+export function resolveProperty(
+  _objService,
+  _cacheService,
+  _configService,
+  moduleCode,
+  elem,
+  val
+): Observable<any> {
+  if (elem.type_widget === 'date' || (elem.type_util === 'date' && val)) {
+    val = Utils.formatDate(val);
   }
 
-function getUtil(_cacheService, typeUtil: string, id, fieldName: string, idFieldName: string | null = null) {
-    if (Array.isArray(id)) {
-      return getUtils(typeUtil, id, fieldName, idFieldName);
-    }
+  const fieldName = _objService.configUtils(elem, moduleCode);
 
-    var urlRelative = `util/${typeUtil}/${id}`;
+  if (val && fieldName && elem.type_widget) {
+    return getUtil(_cacheService, elem.type_util, val, fieldName, elem.value_field_name);
+  }
+  return of(val);
+}
 
-    if (idFieldName) {
-      urlRelative += `?id_field_name=${idFieldName}`;
-    }
+function getUtil(
+  _cacheService,
+  typeUtil: string,
+  id,
+  fieldName: string,
+  idFieldName: string | null = null
+) {
+  if (Array.isArray(id)) {
+    return getUtils(typeUtil, id, fieldName, idFieldName);
+  }
 
-    const sCachePaths = `util|${typeUtil}|${id}`;
-    return _cacheService.cache_or_request('get', urlRelative, sCachePaths).pipe(
-      mergeMap((value) => {
-        let out;
-        if (fieldName === 'all') {
-          out = value;
-        } else if (fieldName.split(',').length >= 2) {
-          for (const fieldNameInter of fieldName.split(',')) {
-            if (value[fieldNameInter]) {
-              out = value[fieldNameInter];
-              break;
-            }
+  var urlRelative = `util/${typeUtil}/${id}`;
+
+  if (idFieldName) {
+    urlRelative += `?id_field_name=${idFieldName}`;
+  }
+
+  const sCachePaths = `util|${typeUtil}|${id}`;
+  return _cacheService.cache_or_request('get', urlRelative, sCachePaths).pipe(
+    mergeMap((value) => {
+      let out;
+      if (fieldName === 'all') {
+        out = value;
+      } else if (fieldName.split(',').length >= 2) {
+        for (const fieldNameInter of fieldName.split(',')) {
+          if (value[fieldNameInter]) {
+            out = value[fieldNameInter];
+            break;
           }
-        } else {
-          out = value[fieldName];
         }
-        return of(out);
-      })
-    );
-  }
+      } else {
+        out = value[fieldName];
+      }
+      return of(out);
+    })
+  );
+}
 
-  function getUtils(typeUtilObject, ids, fieldName, idFieldName) {
-    if (!ids.length) {
-      return of(null);
-    }
-    const observables :any[]= [];
-    for (const id of ids) {
-      observables.push(getUtil(typeUtilObject, id, fieldName, idFieldName));
-    }
-    return forkJoin(observables).pipe(
-      concatMap((res) => {
-        return of(res.join(', '));
-      })
-    );
+function getUtils(typeUtilObject, ids, fieldName, idFieldName) {
+  if (!ids.length) {
+    return of(null);
   }
+  const observables: any[] = [];
+  for (const id of ids) {
+    observables.push(getUtil(typeUtilObject, id, fieldName, idFieldName));
+  }
+  return forkJoin(observables).pipe(
+    concatMap((res) => {
+      return of(res.join(', '));
+    })
+  );
+}


### PR DESCRIPTION
Cette PR ajoute la pagination par le backend pour les listes de Sites et de Groupes de sites dans les pages des protocoles de suivi. Elle résoud le problème de lenteur dans l'affichage de ces pages pour les instances avec beaucoup de données.

L'implémentation modifie le code correspondant du gestionnaire de sites (frontend et backend) pour ajouter la prise en compte optionnelle d'un protocole. C'est une 1ère étape dans une refonte de gn-monitoring pour rassembler le code des protocoles et le code du gestionnaire de sites.

**Changements frontend**

Utilisation des composants provenant de la partie gestionnaire de sites liés aux groupes de site et sites pour la partie module

**Changements backend**

- changement des endpoints liste et geometries des Sites/Groupes écrits pour le gestionnaire de sites afin d'ajouter le support des protocoles :
  + support de la pagination pour les propriétés spécifiques
  + support partiel du tri pour les propriétés spécifiques (le tri sur certains `type_util` n'est pas implémenté)
- ajout des tests correspondants

**Infos pour relecture**

- les commits de refacto mineur indépendants sont marqués "refacto"
- les commits centraux sont :
  + [backend] Ajoute endpoints listes paginées pour Groupes et Sites
  + [backend] Étend et teste tris sur endpoint liste Sites
  + [frontend] use sitesgroups and sites components

**Pour merge :** possible de garder les commits "refacto" séparés et squash des autres commits