### PR TITLE
fix bug sur l'enchainement des saisies

### DIFF
--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -355,6 +355,7 @@ export class MonitoringFormComponent implements OnInit {
       this.obj.monitoringObjectService()
     );
     this.obj.init({});
+    this.obj = this.setQueryParams(this.obj);
 
     this.obj.properties[this.obj.configParam('id_field_Name')] = null;
 


### PR DESCRIPTION
Ce fix corrige l'enchainement des saisies qui provoque une erreur lors de la 2ème observation enchainée.  L'id_visit n'était pas transmis et l'erreur provoquait un blocage de l'application ainsi qu'un comportement dont il n'est pas facile de sortir. Correction faite par Benoît Maurin @unjambonakap
Merci Benoît pour ce dépannage express :+1: