### PR TITLE
feat: add spinner on loading data and geom

### DIFF
--- a/frontend/app/components/monitoring-map/monitoring-map.component.css
+++ b/frontend/app/components/monitoring-map/monitoring-map.component.css
@@ -1,3 +1,47 @@
 :host ::ng-deep .hide-draw-form .leaflet-top.leaflet-left {
   display: none;
 }
+
+#geometry {
+  position:  relative !important;
+}
+
+.spinner-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  width: auto;
+  height: auto;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+
+.spinner-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: white;
+  font-size: 18px;
+}
+
+.spinner {
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-top: 5px solid #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/frontend/app/components/monitoring-map/monitoring-map.component.html
+++ b/frontend/app/components/monitoring-map/monitoring-map.component.html
@@ -1,4 +1,11 @@
 <div id="geometry" class="monitoring-map-container">
+
+  <div *ngIf="!(obj && obj.bIsInitialized)" class="spinner-overlay">
+    <div class="spinner-container">
+      <div class="spinner"></div>
+      <p>Chargement des géométries...</p>
+    </div>
+  </div>
   <pnx-map
     [height]="heightMap"
     [ngClass]="{ 'hide-draw-form': !(bEdit && obj && obj.config['geometry_type']) }"

--- a/frontend/app/components/monitoring-object/monitoring-object.component.css
+++ b/frontend/app/components/monitoring-object/monitoring-object.component.css
@@ -57,3 +57,49 @@
 .scroll {
   overflow-y: scroll;
 }
+
+
+#monitoring-elem-container {
+  position:  relative !important;
+}
+
+.spinner-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  width: auto;
+  height: auto;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+
+.spinner-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: white;
+  font-size: 18px;
+}
+
+.spinner {
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-top: 5px solid #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+

--- a/frontend/app/components/monitoring-object/monitoring-object.component.html
+++ b/frontend/app/components/monitoring-object/monitoring-object.component.html
@@ -14,6 +14,14 @@
     </div>
 
     <div id="monitoring-elem-container" class="cadre scroll">
+
+      <div *ngIf="!(obj && obj.bIsInitialized)" class="spinner-overlay">
+        <div class="spinner-container">
+          <div class="spinner"></div>
+          <p>Chargement des données...</p>
+        </div>
+      </div>
+
       <pnx-monitoring-breadcrumbs *ngIf="obj && obj.bIsInitialized" [obj]="obj"
         [(bEdit)]="bEdit"></pnx-monitoring-breadcrumbs>
 


### PR DESCRIPTION
Cette PR est une proposition d'amélioration concernant l'affichage d'un spinner indiquant le chargement des géométries et des données lorsqu'on entre par les protocoles dans monitoring.

![image](https://github.com/user-attachments/assets/124a49e0-9714-4ee4-ad88-05bd7adac743)


Reviewed-by: andriacap