### PR TITLE
fix: remove legacy filters from site route + allow filtering type_sites by name

### DIFF
--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -124,7 +124,9 @@ class SitesQuery(GnMonitoringGenericFilter):
             if not isinstance(value, list):
                 value = [value]
             if value[0].isdigit():
-                query = query.filter(cls.types_site.any(Models.BibTypeSite.id_nomenclature_type_site.in_(value)))
+                query = query.filter(
+                    cls.types_site.any(Models.BibTypeSite.id_nomenclature_type_site.in_(value))
+                )
             else:
                 # HACK gestionnaire des sites
                 # Quand filtre sur type de site envoie une chaine de caractère

--- a/backend/gn_module_monitoring/monitoring/queries.py
+++ b/backend/gn_module_monitoring/monitoring/queries.py
@@ -1,24 +1,19 @@
-from flask import g
-
 import json
 from copy import copy
 
-from sqlalchemy import Unicode, and_, Unicode, func, or_, false, true, select
-from sqlalchemy.orm import class_mapper
-from sqlalchemy.types import DateTime
-from sqlalchemy.sql.expression import Select
-from werkzeug.datastructures import MultiDict
-from sqlalchemy.orm import aliased
-
+from apptax.taxonomie.models import Taxref
+from flask import g
+from geonature.core.gn_permissions.tools import get_scopes_by_action
+from geonature.utils.env import db
+from pypnnomenclature.models import TNomenclatures
 from pypnusershub.db.models import User
 from ref_geo.models import LAreas
-from apptax.taxonomie.models import Taxref
+from sqlalchemy import Unicode, and_, false, func, or_, select, true
+from sqlalchemy.orm import aliased, class_mapper
+from sqlalchemy.sql.expression import Select
+from sqlalchemy.types import DateTime
+from werkzeug.datastructures import MultiDict
 
-from geonature.utils.env import db
-
-from geonature.core.gn_permissions.tools import get_scopes_by_action
-from geonature.core.gn_commons.models import TModules
-from pypnnomenclature.models import TNomenclatures
 import gn_module_monitoring.monitoring.models as Models
 
 
@@ -120,10 +115,20 @@ class SitesQuery(GnMonitoringGenericFilter):
 
     @classmethod
     def filter_by_params(cls, query: Select, params: MultiDict = None, **kwargs):
-
         if "modules" in params:
             query = query.filter(cls.modules.any(id_module=params["modules"]))
             params.pop("modules")
+
+        if "types_site" in params:
+            value = params["types_site"]
+            if not isinstance(value, list):
+                value = [value]
+            if value[0].isdigit():
+                query = query.filter(cls.types_site.any(Models.BibTypeSite.id_nomenclature_type_site.in_(value)))
+            else:
+                # HACK gestionnaire des sites
+                # Quand filtre sur type de site envoie une chaine de caractère
+                params["types_site_label"] = value[0]
         if "types_site_label" in params:
             value = params["types_site_label"]
             join_types_site = aliased(Models.BibTypeSite)
@@ -131,13 +136,6 @@ class SitesQuery(GnMonitoringGenericFilter):
             query = query.join(join_types_site, cls.types_site)
             query = query.join(join_nomenclature_type_site, join_types_site.nomenclature)
             query = query.filter(join_nomenclature_type_site.label_default.ilike(f"%{value}%"))
-        if "types_site" in params:
-            value = params["types_site"]
-            if not isinstance(value, list):
-                value = [value]
-            query = query.filter(
-                cls.types_site.any(Models.BibTypeSite.id_nomenclature_type_site.in_(value))
-            )
 
         query = super().filter_by_params(query, params)
         return query

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -1,12 +1,9 @@
 import pytest
-
 from flask import url_for
-
 from pypnusershub.tests.utils import set_logged_user_cookie
 
 from gn_module_monitoring.monitoring.models import TMonitoringSites
 from gn_module_monitoring.monitoring.schemas import BibTypeSiteSchema, MonitoringSitesSchema
-from gn_module_monitoring.monitoring.models import TMonitoringSites
 from gn_module_monitoring.tests.fixtures.generic import *
 
 
@@ -98,6 +95,20 @@ class TestSite:
         )
         assert nb_results == r.json["count"]
         assert r.json["count"] == len(sites)
+
+    def test_get_sites_filters_types_site(self, sites, types_site, monitorings_users):
+        set_logged_user_cookie(self.client, monitorings_users["admin_user"])
+
+        r = self.client.get(
+            url_for("monitorings.get_sites", types_site=types_site["Test_Grotte"].id_nomenclature_type_site)
+        )
+        assert r.json["count"] == 2
+
+        r = self.client.get(url_for("monitorings.get_sites", types_site="Test_Grotte"))
+        assert r.json["count"] == 2
+
+        r = self.client.get(url_for("monitorings.get_sites", types_site_label="Test_Grotte"))
+        assert r.json["count"] == 2
 
     def test_get_sites_limit(self, sites, monitorings_users):
         set_logged_user_cookie(self.client, monitorings_users["admin_user"])

--- a/backend/gn_module_monitoring/tests/test_routes/test_site.py
+++ b/backend/gn_module_monitoring/tests/test_routes/test_site.py
@@ -100,7 +100,10 @@ class TestSite:
         set_logged_user_cookie(self.client, monitorings_users["admin_user"])
 
         r = self.client.get(
-            url_for("monitorings.get_sites", types_site=types_site["Test_Grotte"].id_nomenclature_type_site)
+            url_for(
+                "monitorings.get_sites",
+                types_site=types_site["Test_Grotte"].id_nomenclature_type_site,
+            )
         )
         assert r.json["count"] == 2
 

--- a/backend/gn_module_monitoring/utils/routes.py
+++ b/backend/gn_module_monitoring/utils/routes.py
@@ -1,29 +1,27 @@
+from typing import Tuple
+
 from flask import Response, g
 from flask.json import jsonify
-
-from typing import Tuple
-from marshmallow import Schema
-from werkzeug.datastructures import MultiDict
-from sqlalchemy import cast, func, text, select, and_
-from sqlalchemy.dialects.postgresql import JSON
-from sqlalchemy.orm import load_only, aliased
-from sqlalchemy.sql.expression import Select
-
-from geonature.utils.env import DB
-from geonature.core.gn_permissions.models import PermObject, PermissionAvailable
 from geonature.core.gn_monitoring.models import BibTypeSite
+from geonature.core.gn_permissions.models import PermissionAvailable, PermObject
+from geonature.utils.env import DB
 from geonature.utils.errors import GeoNatureError
-
-from pypnusershub.db.models import User
+from marshmallow import Schema
 from pypnnomenclature.models import TNomenclatures
+from pypnusershub.db.models import User
+from sqlalchemy import and_, cast, func, select, text
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.orm import aliased, load_only
+from sqlalchemy.sql.expression import Select
+from werkzeug.datastructures import MultiDict
 
 from gn_module_monitoring.monitoring.models import (
+    TBaseSites,
+    TModules,
     TMonitoringSites,
     TMonitoringSitesGroups,
-    cor_site_type,
-    TBaseSites,
     cor_module_type,
-    TModules,
+    cor_site_type,
 )
 from gn_module_monitoring.monitoring.schemas import paginate_schema
 
@@ -155,28 +153,6 @@ def query_all_types_site_from_module_id(id_module: int = None):
         )
         query = query.where(cor_module_type.c.id_module == id_module)
     return DB.session.scalars(query).unique().all()
-
-
-def filter_according_to_column_type_for_site(query, params):
-    if "types_site" in params:
-        params_types_site = params.pop("types_site")
-        query = (
-            query.join(TMonitoringSites.types_site)
-            .join(BibTypeSite.nomenclature)
-            .where(TNomenclatures.label_fr.ilike(f"%{params_types_site}%"))
-        )
-    elif "id_inventor" in params:
-        params_inventor = params.pop("id_inventor")
-
-        aliased_User = aliased(User)
-        query = query.join(
-            aliased_User,
-            aliased_User.id_role == TMonitoringSites.id_inventor,
-        ).where(aliased_User.nom_complet.ilike(f"%{params_inventor}%"))
-    if len(params) != 0:
-        query = filter_params(TMonitoringSites, query=query, params=params)
-
-    return query
 
 
 def sort_according_to_column_type_for_site(query, sort_label, sort_dir):


### PR DESCRIPTION
- remove legacy filters from `filter_according_to_column_type_for_site` function
- allow to filter by type_site name (not only ID)
- Use Ruff to format imports order