### PR TITLE
fix: request too long for get_module_by_id_base_site

### DIFF
--- a/backend/gn_module_monitoring/tests/fixtures/module.py
+++ b/backend/gn_module_monitoring/tests/fixtures/module.py
@@ -111,3 +111,112 @@ def monitoring_module_wo_types_site():
         db.session.add(t_monitoring_module)
 
     return t_monitoring_module
+
+
+@pytest.fixture
+def modules_with_and_without_permission(types_site, monitorings_users):
+    user = monitorings_users["admin_user"]
+
+    module_with_perm = TMonitoringModules(
+        module_code="WITH_PERM",
+        module_label="Module With Perm",
+        uuid_module_complement=uuid4(),
+        module_path="with_perm",
+        active_frontend=True,
+        active_backend=False,
+        types_site=list(types_site.values()),
+    )
+
+    module_without_perm = TMonitoringModules(
+        module_code="NO_PERM",
+        module_label="Module Without Perm",
+        uuid_module_complement=uuid4(),
+        module_path="no_perm",
+        active_frontend=True,
+        active_backend=False,
+        types_site=list(types_site.values()),
+    )
+
+    with db.session.begin_nested():
+        db.session.add_all([module_with_perm, module_without_perm])
+
+        action_r = db.session.execute(
+            select(PermAction).where(PermAction.code_action == "R")
+        ).scalar_one()
+
+        # PermObjets
+        objects = {
+            code: db.session.execute(
+                select(PermObject).where(PermObject.code_object == code)
+            ).scalar_one()
+            for code in [
+                "MONITORINGS_MODULES",
+                "MONITORINGS_GRP_SITES",
+                "MONITORINGS_SITES",
+                "MONITORINGS_VISITES",
+            ]
+        }
+
+        # Ajout de droits complets sur tous les objets (y compris VISITES)
+        for obj in objects.values():
+            db.session.add(
+                Permission(
+                    role=user,
+                    action=action_r,
+                    module=module_with_perm,
+                    object=obj,
+                    scope_value=None,
+                    sensitivity_filter=None,
+                )
+            )
+
+        # Ajout de droits limités pour module_without_perm (pas MONITORINGS_VISITES)
+        for code in ["MONITORINGS_MODULES", "MONITORINGS_GRP_SITES", "MONITORINGS_SITES"]:
+            db.session.add(
+                Permission(
+                    role=user,
+                    action=action_r,
+                    module=module_without_perm,
+                    object=objects[code],
+                    scope_value=None,
+                    sensitivity_filter=None,
+                )
+            )
+
+    return {"with_perm": module_with_perm, "without_perm": module_without_perm}
+
+
+@pytest.fixture
+def modules_with_permissions_and_different_types(types_site, monitorings_users):
+    admin_user = monitorings_users["admin_user"]
+    modules = {}
+
+    with db.session.begin_nested():
+        action_r = db.session.execute(
+            select(PermAction).where(PermAction.code_action == "R")
+        ).scalar_one()
+        perm_object = db.session.execute(
+            select(PermObject).where(PermObject.code_object == "MONITORINGS_VISITES")
+        ).scalar_one()
+
+        for label, type_site in types_site.items():
+            module = TMonitoringModules(
+                module_code=f"MOD_{label}",
+                module_label=f"Module {label}",
+                module_path=f"path_{label}",
+                uuid_module_complement=uuid4(),
+                active_frontend=True,
+                active_backend=True,
+                types_site=[type_site],
+            )
+            db.session.add(module)
+
+            # On donne la permission "R"
+            permission = Permission(
+                role=admin_user, action=action_r, module=module, object=perm_object
+            )
+            db.session.add(permission)
+
+            modules[label] = module
+
+    return {"admin_user": admin_user, "modules": modules}


### PR DESCRIPTION
- Change sql request to get list of id_module according to get_module_by_id_base_site
- Before , route's duration is around 30-50sec
- After with new query , route's duration is less than 1sec 0.0016 s
- Add tests to related to the route get_module_by_id_base_site with different permission and different association module -type_site

Request before 

```sql

select
	gn_commons.t_modules.type,
	gn_monitoring.t_module_complements.id_module,
	gn_commons.t_modules.id_module as id_module_1,
	gn_commons.t_modules.module_code,
	gn_commons.t_modules.module_label,
	gn_commons.t_modules.module_picto,
	gn_commons.t_modules.module_desc,
	gn_commons.t_modules.module_group,
	gn_commons.t_modules.module_path,
	gn_commons.t_modules.module_external_url,
	gn_commons.t_modules.module_target,
	gn_commons.t_modules.module_comment,
	gn_commons.t_modules.active_frontend,
	gn_commons.t_modules.active_backend,
	gn_commons.t_modules.module_doc_url,
	gn_commons.t_modules.module_order,
	gn_commons.t_modules.ng_module,
	gn_commons.t_modules.meta_create_date,
	gn_commons.t_modules.meta_update_date,
	gn_monitoring.t_module_complements.uuid_module_complement,
	gn_monitoring.t_module_complements.id_list_observer,
	gn_monitoring.t_module_complements.id_list_taxonomy,
	gn_monitoring.t_module_complements.taxonomy_display_field_name,
	gn_monitoring.t_module_complements.b_synthese,
	gn_monitoring.t_module_complements.b_draw_sites_group,
	gn_monitoring.t_module_complements.data,
	t_base_sites_1.id_base_site,
	t_base_sites_1.id_inventor,
	t_base_sites_1.id_digitiser,
	t_base_sites_1.base_site_name,
	t_base_sites_1.base_site_description,
	t_base_sites_1.base_site_code,
	t_base_sites_1.first_use_date,
	ST_AsEWKB(t_base_sites_1.geom) as geom,
	t_base_sites_1.uuid_base_site,
	t_base_sites_1.meta_create_date as meta_create_date_1,
	t_base_sites_1.meta_update_date as meta_update_date_1,
	t_base_sites_1.altitude_min,
	t_base_sites_1.altitude_max,
	bib_type_site_1.id_nomenclature_type_site,
	bib_type_site_1.config
from
	gn_commons.t_modules
join gn_monitoring.t_module_complements on
	gn_commons.t_modules.id_module = gn_monitoring.t_module_complements.id_module
left outer join (gn_monitoring.cor_module_type as cor_module_type_1
join gn_monitoring.bib_type_site as bib_type_site_1 on
	bib_type_site_1.id_nomenclature_type_site = cor_module_type_1.id_type_site) on
	gn_commons.t_modules.id_module = cor_module_type_1.id_module
left outer join (gn_monitoring.cor_site_type as cor_site_type_1
join gn_monitoring.t_base_sites as t_base_sites_1 on
	t_base_sites_1.id_base_site = cor_site_type_1.id_base_site) on
	bib_type_site_1.id_nomenclature_type_site = cor_site_type_1.id_type_site
where
	gn_monitoring.t_module_complements.id_module in (__[POSTCOMPILE_id_module_2])
	and (exists (
	select
		1
	from
		gn_monitoring.cor_module_type,
		gn_monitoring.bib_type_site
	where
		gn_commons.t_modules.id_module = gn_monitoring.cor_module_type.id_module
		and gn_monitoring.bib_type_site.id_nomenclature_type_site = gn_monitoring.cor_module_type.id_type_site
		and (exists (
		select
			1
		from
			gn_monitoring.cor_site_type,
			gn_monitoring.t_base_sites
		where
			gn_monitoring.bib_type_site.id_nomenclature_type_site = gn_monitoring.cor_site_type.id_type_site
			and gn_monitoring.t_base_sites.id_base_site = gn_monitoring.cor_site_type.id_base_site
			and gn_monitoring.t_base_sites.id_base_site = :id_base_site_1))))
```

Request after 

```sql
select
	distinct gn_commons.t_modules.type,
	gn_monitoring.t_module_complements.id_module,
	gn_commons.t_modules.id_module as id_module_1,
	gn_commons.t_modules.module_code,
	gn_commons.t_modules.module_label,
	gn_commons.t_modules.module_picto,
	gn_commons.t_modules.module_desc,
	gn_commons.t_modules.module_group,
	gn_commons.t_modules.module_path,
	gn_commons.t_modules.module_external_url,
	gn_commons.t_modules.module_target,
	gn_commons.t_modules.module_comment,
	gn_commons.t_modules.active_frontend,
	gn_commons.t_modules.active_backend,
	gn_commons.t_modules.module_doc_url,
	gn_commons.t_modules.module_order,
	gn_commons.t_modules.ng_module,
	gn_commons.t_modules.meta_create_date,
	gn_commons.t_modules.meta_update_date,
	gn_monitoring.t_module_complements.uuid_module_complement,
	gn_monitoring.t_module_complements.id_list_observer,
	gn_monitoring.t_module_complements.id_list_taxonomy,
	gn_monitoring.t_module_complements.taxonomy_display_field_name,
	gn_monitoring.t_module_complements.b_synthese,
	gn_monitoring.t_module_complements.b_draw_sites_group,
	gn_monitoring.t_module_complements.data
from
	gn_commons.t_modules
join gn_monitoring.t_module_complements on
	gn_commons.t_modules.id_module = gn_monitoring.t_module_complements.id_module
join gn_monitoring.cor_module_type on
	gn_monitoring.cor_module_type.id_module = gn_monitoring.t_module_complements.id_module
join gn_monitoring.cor_site_type on
	gn_monitoring.cor_site_type.id_type_site = gn_monitoring.cor_module_type.id_type_site
	and gn_monitoring.cor_site_type.id_base_site = :id_base_site_1
where
	gn_monitoring.t_module_complements.id_module in (__[POSTCOMPILE_id_module_2])
```

Closes: #434 

Reviewed-by: andriacap