### PR TITLE
Changelog 1.0.0 - Mention PostGIS 3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,7 +35,8 @@
 
 ## 1.0.0 (2024-12-13)
 
-Nécessite GeoNature 2.15.0 (ou plus)
+Nécessite GeoNature 2.15.0 (ou plus).
+L'utilisation de la fonction `ST_AsGeoJSON` nécessite PostGIS version 3 minimum.
 
 **🚀 Nouveautés**
 


### PR DESCRIPTION
@amandine-sahl, je ne suis pas certain si c'est dans la 1.0.0, avant ou après que l'utilisation de `ST_AsGeoJSON` a été intégré et donc l'obligation que le PostGIS de la BDD GeoNature soit en version 3 minimum ?