### PR TITLE
MAJ Synthese - Autoriser les noms de module en majuscules

### DIFF
--- a/backend/gn_module_monitoring/monitoring/repositories.py
+++ b/backend/gn_module_monitoring/monitoring/repositories.py
@@ -84,7 +84,7 @@ class MonitoringObject(MonitoringObjectSerializer):
         if self._object_type == "module" and not process_module:
             return
 
-        table_name = "v_synthese_{}".format(self._module_code)
+        table_name = "v_synthese_{}".format(self._module_code.lower())
 
         # Test de l'existance de la colonne de synchronisation sur la vue synthese
         column_exist = DB.engine.execute(


### PR DESCRIPTION
cf --> https://github.com/PnX-SI/gn_module_monitoring/issues/449

Lorsque le nom du module comporte des majuscules, une erreur silencieuse est levée et bloque la mise à jour de la synthèse. Pas d'erreur en interface mais erreurs dans les logs et les données ne transites pas de monitoring vers la synthèse.

Suite à la correction proposée ici, j'ai pu lancer des synchronisation depuis les boutons "Mettre à jour la synthèse" de chacun des modules monitorings.