### PR TITLE
fix(.gitmodules): make geonature submodule url generic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "dependencies/GeoNature"]
 	path = dependencies/GeoNature
-	url = git@github.com:PnX-SI/GeoNature.git
+	url = ../GeoNature.git
     branch = develop


### PR DESCRIPTION
Allows `GeoNature` submodule URL protocol to be consistent with protocol used for remote of root repository `gn_module_monitoring`: Git SSH, HTTPS.