### PR TITLE
Feat: add config dynamic synthese module filters

### DIFF
--- a/backend/gn_module_monitoring/conf_schema_toml.py
+++ b/backend/gn_module_monitoring/conf_schema_toml.py
@@ -20,6 +20,10 @@ PERMISSION_LEVEL_DEFAULT = {
 }
 
 
+class DynamicFormDefSchema(Schema):
+    fields = fields.List(fields.Dict())
+
+
 class GnModuleSchemaConf(Schema):
     DESCRIPTION_MODULE = fields.String(load_default="")
     TITLE_MODULE = fields.String(load_default="Module monitoring")
@@ -27,6 +31,12 @@ class GnModuleSchemaConf(Schema):
 
     PERMISSION_LEVEL = fields.Dict(
         keys=fields.Str(), values=fields.Str(), load_default=PERMISSION_LEVEL_DEFAULT
+    )
+    DYNAMIC_FORM_DEF_MONITORING = fields.Dict(
+        keys=fields.Str(),  # module_code
+        values=fields.Nested(DynamicFormDefSchema),
+        required=False,
+        load_default={},
     )
 
 

--- a/backend/gn_module_monitoring/conf_schema_toml.py
+++ b/backend/gn_module_monitoring/conf_schema_toml.py
@@ -21,7 +21,8 @@ PERMISSION_LEVEL_DEFAULT = {
 
 
 class DynamicFormDefSchema(Schema):
-    fields = fields.List(fields.Dict())
+    fields_form = fields.List(fields.Dict())
+    show_advanced_filters = fields.Boolean(load_default=False)
 
 
 class GnModuleSchemaConf(Schema):
@@ -32,8 +33,9 @@ class GnModuleSchemaConf(Schema):
     PERMISSION_LEVEL = fields.Dict(
         keys=fields.Str(), values=fields.Str(), load_default=PERMISSION_LEVEL_DEFAULT
     )
+    SHOW_ADVANCED_FILTERS = fields.Boolean(load_default=False)
     DYNAMIC_FORM_DEF_MONITORING = fields.Dict(
-        keys=fields.Str(),  # module_code
+        keys=fields.Str(),
         values=fields.Nested(DynamicFormDefSchema),
         required=False,
         load_default={},

--- a/backend/gn_module_monitoring/routes/modules.py
+++ b/backend/gn_module_monitoring/routes/modules.py
@@ -2,7 +2,7 @@
 routes pour les modules de suivis...
 """
 
-from flask import request, jsonify
+from flask import request
 from utils_flask_sqla.response import json_resp_accept_empty_list, json_resp
 
 from geonature.core.gn_permissions.tools import get_scopes_by_action, has_any_permissions_by_action
@@ -97,8 +97,3 @@ def get_all_types_site_from_module_id(module_code):
     types_site = query_all_types_site_from_module_id(id_module)
     schema = BibTypeSiteSchema()
     return [schema.dump(res) for res in types_site]
-    
-@blueprint.route("/_internal/modules", methods=["GET"])
-def get_modules_api_internal():
-    modules = get_modules()
-    return jsonify([m.module_code for m in modules])

--- a/backend/gn_module_monitoring/routes/modules.py
+++ b/backend/gn_module_monitoring/routes/modules.py
@@ -2,7 +2,7 @@
 routes pour les modules de suivis...
 """
 
-from flask import request
+from flask import request, jsonify
 from utils_flask_sqla.response import json_resp_accept_empty_list, json_resp
 
 from geonature.core.gn_permissions.tools import get_scopes_by_action, has_any_permissions_by_action
@@ -97,3 +97,8 @@ def get_all_types_site_from_module_id(module_code):
     types_site = query_all_types_site_from_module_id(id_module)
     schema = BibTypeSiteSchema()
     return [schema.dump(res) for res in types_site]
+    
+@blueprint.route("/_internal/modules", methods=["GET"])
+def get_modules_api_internal():
+    modules = get_modules()
+    return jsonify([m.module_code for m in modules])

--- a/backend/gn_module_monitoring/utils/enrich_config.py
+++ b/backend/gn_module_monitoring/utils/enrich_config.py
@@ -1,17 +1,40 @@
 from flask import current_app
-import requests
 from .form_enricher import enrich_monitoring_form_def
+from gn_module_monitoring.modules.repositories import (
+    get_modules,
+)
+from geonature.core.gn_permissions.tools import get_scopes_by_action
 
 
 def enrich_config_from_remote(form_def_dict, _=None):
-    api_endpoint = current_app.config["API_ENDPOINT"]
-    base_url = current_app.config["MONITORINGS"]["MODULE_URL"]
     try:
-        response = requests.get(f"{api_endpoint}{base_url}/_internal/modules", timeout=5)
-        response.raise_for_status()
-        module_codes = response.json()
+        modules = get_modules()
+        # modules_out = []
+        modules_out = [enrich_module(module) for module in modules if has_read_permission(module)]
     except Exception as e:
-        current_app.logger.warning(f"Erreur appel modules monitoring : {e}")
-        module_codes = []
+        current_app.logger.warning(f"Erreur lecture modules monitoring : {e}")
+        modules_out = []
 
-    return enrich_monitoring_form_def(form_def_dict or {}, module_codes)
+    return enrich_monitoring_form_def(form_def_dict or {}, modules_out)
+
+
+def enrich_module(module):
+    module_out = module.as_dict(depth=0)
+    module_out["cruved"] = get_scopes_by_action(
+        module_code=module.module_code, object_code="MONITORINGS_MODULES"
+    )
+    return module_out
+
+
+def has_read_permission(module):
+    """Retourne True si l'utilisateur a le droit de lecture (R > 0) sur le module."""
+    try:
+        scopes = get_scopes_by_action(
+            module_code=module.module_code, object_code="MONITORINGS_MODULES"
+        )
+        return scopes.get("R", 0) > 0
+    except Exception as e:
+        current_app.logger.warning(
+            f"[Monitoring] Erreur permission module {module.module_code} : {e}"
+        )
+        return False

--- a/backend/gn_module_monitoring/utils/enrich_config.py
+++ b/backend/gn_module_monitoring/utils/enrich_config.py
@@ -1,0 +1,17 @@
+from flask import current_app
+import requests
+from .form_enricher import enrich_monitoring_form_def
+
+
+def enrich_config_from_remote(form_def_dict, _=None):
+    api_endpoint = current_app.config["API_ENDPOINT"]
+    base_url = current_app.config["MONITORINGS"]["MODULE_URL"]
+    try:
+        response = requests.get(f"{api_endpoint}{base_url}/_internal/modules", timeout=5)
+        response.raise_for_status()
+        module_codes = response.json()
+    except Exception as e:
+        current_app.logger.warning(f"Erreur appel modules monitoring : {e}")
+        module_codes = []
+
+    return enrich_monitoring_form_def(form_def_dict or {}, module_codes)

--- a/backend/gn_module_monitoring/utils/form_enricher.py
+++ b/backend/gn_module_monitoring/utils/form_enricher.py
@@ -1,0 +1,34 @@
+from gn_module_monitoring.config.utils import config_from_files
+
+
+def enrich_monitoring_form_def(form_def_dict, module_codes):
+    enriched_dict = {}
+
+    def get_case_insensitive_key(d: dict, key: str):
+        for k, v in d.items():
+            if k.lower() == key.lower():
+                return v
+        return None
+
+    for protocole_code in module_codes:
+        observation_def = config_from_files("observation", protocole_code)
+        protocole_form = get_case_insensitive_key(form_def_dict, protocole_code)
+        fields = protocole_form.get("fields", [])
+
+        enriched_fields = []
+        for field in fields:
+            attr = field.get("attribut_name")
+            if not attr:
+                continue
+
+            obs_def = observation_def.get("specific", {}).get(attr)
+            if not obs_def:
+                enriched_fields.append(field)
+                continue
+
+            enriched = {**obs_def, **field}  # priorité au champ TOML
+            enriched_fields.append(enriched)
+
+        enriched_dict[protocole_code] = {"fields": enriched_fields}
+
+    return enriched_dict

--- a/backend/gn_module_monitoring/utils/form_enricher.py
+++ b/backend/gn_module_monitoring/utils/form_enricher.py
@@ -10,10 +10,11 @@ def enrich_monitoring_form_def(form_def_dict, module_codes):
                 return v
         return None
 
-    for protocole_code in module_codes:
+    for module in module_codes:
+        protocole_code = module["module_code"]
         observation_def = config_from_files("observation", protocole_code)
         protocole_form = get_case_insensitive_key(form_def_dict, protocole_code)
-        fields = protocole_form.get("fields", [])
+        fields = protocole_form.get("fields_form", [])
 
         enriched_fields = []
         for field in fields:
@@ -29,6 +30,6 @@ def enrich_monitoring_form_def(form_def_dict, module_codes):
             enriched = {**obs_def, **field}  # priorité au champ TOML
             enriched_fields.append(enriched)
 
-        enriched_dict[protocole_code] = {"fields": enriched_fields}
+        enriched_dict[protocole_code] = {"fields_form": enriched_fields}
 
     return enriched_dict

--- a/monitorings_config.toml.example
+++ b/monitorings_config.toml.example
@@ -6,3 +6,16 @@
 
 # code of the observator list -- utilisateurs.t_listes
 #CODE_OBSERVERS_LIST = "obsocctax"
+
+# Possibilité d'afficher les filtres avancées , liés aux champs additionnel, dans la synthese
+# SHOW_ADVANCED_FILTERS = false
+
+# Possibilité de configurer plus finement les filtres avancées à afficher et en définissant également les champs que l'on veut filtrer
+# Penser à bien remplacer le MODULE_CODE par le code du sous module . Par exemple CHIROPTERES . Et également penser à définir les champs pour lequels on veut filtrer dans la synthese . 
+# Pour les champs s'appuyer sur les champs spécifiques au sous module (protocole) liés au formulaire d'observation.
+[DYNAMIC_FORM_DEF_MONITORING.<MODULE_CODE>]
+fields_form = [
+    { attribut_name = "key_field_of_nomenclature", keyValue ="label_fr"},
+    { attribut_name = "key_field_of_radio_button" }
+]
+show_advanced_filters = true

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
             "blueprint = gn_module_monitoring.blueprint:blueprint",
             "config_schema = gn_module_monitoring.conf_schema_toml:GnModuleSchemaConf",
             "migrations = gn_module_monitoring:migrations",
+            "form_def_enricher = gn_module_monitoring.utils.enrich_config:enrich_config_from_remote",
         ],
     },
     classifiers=[


### PR DESCRIPTION
Cette PR propose une implémentation de nouveaux champs dans la configuration du module monitoring afin de pouvoir filtrer sur les champs additionnels qui sont envoyé dans la synthese . 

Les développements proposés permettent d'utiliser le fichier `observation.json` de chaque protocole pour pouvoir enrichier les filtres que l'on souhaite afficher dans le module de synthèse. 

Une explication plus détaillée a été rédigée ici dans le dépot de GeoNature : https://github.com/PnX-SI/GeoNature/issues/3662 .

Les développements proposés peuvent certainement être améliorés. Je suis disponible pour discuter , échanger et ouvert à toute suggestion d'amélioraiton . Vous pouvez tester les développements en utilisant les deux branches suivantes liées à la PR coté  GeoNature :

- https://github.com/PnX-SI/GeoNature/pull/3663

Ainsi que la branche liée à cette PR coté monitoring .