### PR TITLE
fix: problem to get parent object

### DIFF
--- a/frontend/app/class/monitoring-object.ts
+++ b/frontend/app/class/monitoring-object.ts
@@ -118,7 +118,7 @@ export class MonitoringObject extends MonitoringObjectBase {
       return of({});
     }
     for (const parentType of this.parentTypes()) {
-      if ((cruved['parentType'] || {}).R > 0) {
+      if ((cruved[parentType] || {}).R > 0) {
         promises[parentType] = this.getParent(parentType, depth, cruved);
       } else {
         promises[parentType] = of({});


### PR DESCRIPTION
- put variable instead of literal string parentType

closes: #530 

Reviewed-by: andriacap