### PR TITLE
fix: hardcoded parents path on seeDetails method

### DIFF
--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -229,10 +229,17 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   }
 
   seeDetails($event) {
+    const parentsPath = [...this.parentsPath];
+    if (!parentsPath.includes('module')) {
+      parentsPath.unshift('module');
+    }
+    if (!parentsPath.includes('site')) {
+      parentsPath.push('site');
+    }
     this.router.navigate(
       [`/monitorings/object/${$event.module.module_code}/visit/${$event.id_base_visit}`],
       {
-        queryParams: { parents_path: ['module', 'site'] },
+        queryParams: { parents_path: parentsPath },
       }
     );
   }
@@ -263,8 +270,13 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   }
 
   editChild($event) {
-    const parentsPath = this.parentsPath;
-    parentsPath.push('site');
+    const parentsPath = [...this.parentsPath];
+    if (!parentsPath.includes('module')) {
+      parentsPath.unshift('module');
+    }
+    if (!parentsPath.includes('site')) {
+      parentsPath.push('site');
+    }
     this.router.navigate(
       [
         `monitorings/object/${$event.module.module_code}/visit/${$event.id_base_visit}`,


### PR DESCRIPTION
- Breadcrumb changes on click details visit cause of hardcoded [module, site] (site group is not included)
- Context parent path wasn't persistant (loss of site group)

fix #539 
Reviewed-by: andriacap