### PR TITLE
fix: hardcoded parents path on seeDetails method (#540)

### DIFF
--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -230,9 +230,6 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
 
   seeDetails($event) {
     const parentsPath = [...this.parentsPath];
-    if (!parentsPath.includes('module')) {
-      parentsPath.unshift('module');
-    }
     if (!parentsPath.includes('site')) {
       parentsPath.push('site');
     }
@@ -271,9 +268,6 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
 
   editChild($event) {
     const parentsPath = [...this.parentsPath];
-    if (!parentsPath.includes('module')) {
-      parentsPath.unshift('module');
-    }
     if (!parentsPath.includes('site')) {
       parentsPath.push('site');
     }


### PR DESCRIPTION
- Breadcrumb changes on click details visit cause of hardcoded [module, site] (site group is not included)
- Context parent path wasn't persistant (loss of site group)

Reviewed-by: andriac