### PR TITLE
Modification du process_sql

### DIFF
--- a/backend/gn_module_monitoring/command/utils.py
+++ b/backend/gn_module_monitoring/command/utils.py
@@ -109,6 +109,7 @@ def execute_sql_file(dir, file, module_code, forbidden_instruction=[]):
 
     """
     sql_content = Path(Path(dir) / file).read_text()
+    sql_content = sql_content.replace("v_synthese_:module_code",f"v_synthese_{module_code}") # On remplace explicitement le module_code dans le sql_content
     for sql_cmd in forbidden_instruction:
         if sql_cmd.lower() in sql_content.lower():
             raise Exception(

--- a/data/synthese_svo.sql
+++ b/data/synthese_svo.sql
@@ -29,7 +29,7 @@ WITH source AS (
         id_source
 
     FROM gn_synthese.t_sources
-	WHERE name_source = CONCAT('MONITORING_', UPPER(:'module_code'))
+	WHERE name_source = CONCAT('MONITORING_', UPPER(:module_code))
 	LIMIT 1
 
 ), sites AS (
@@ -37,6 +37,7 @@ WITH source AS (
     SELECT
 
         id_base_site,
+		base_site_name,
         geom AS the_geom_4326,
 	    ST_CENTROID(geom) AS the_geom_point,
 	    geom_local as geom_local
@@ -113,6 +114,7 @@ SELECT
 		--digital_proofvue
 		alt.altitude_min,
 		alt.altitude_max,
+		s.base_site_name as place_name,
 		s.the_geom_4326,
 		s.the_geom_point,
 		s.geom_local as the_geom_local,


### PR DESCRIPTION
* Modification du fichier `gn_module_monitoring/backend/gn_module_monitoring/command/utils.py` pour ajouter un "replace" plus explicite pour le module_code car `DROP VIEW IF EXISTS gn_monitoring.v_synthese_:module_code;
CREATE VIEW gn_monitoring.v_synthese_:module_code AS` n'est pas reconnu par PostgreSQL
* Modification du fichier `gn_module_monitoring/data/synthese_svo.sql` : le code `CONCAT('MONITORING_', UPPER(:'module_code'))` n'est pas reconnu par PostgreSQL
* Ajout de la colonne `base_site_name` pour intégration dans la colonne `place_name` de la synthèse dans le modèle par défaut