### PR TITLE
Fix default filters

### DIFF
--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -132,7 +132,6 @@ export class MonitoringDatatableGComponent implements OnInit {
     //   this.objectType = newObjType;
     // });
     // Initialisation des filtres
-    this.clearFilters();
     this.filterSubject.pipe(debounceTime(500)).subscribe(() => {
       this.filter();
     });

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -310,8 +310,9 @@ export class MonitoringDatatableGComponent implements OnInit {
   }
 
   private clearFilters() {
-    this.filters = {};
+    this.filters = this.dataTableConfig[0].config.filters;
     this.initSort();
+    this.filter();
   }
 
   private updateDataTable(objChanges: SimpleChange) {

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -309,7 +309,7 @@ export class MonitoringDatatableGComponent implements OnInit {
   }
 
   private clearFilters() {
-    this.filters = this.dataTableConfig[0].config.filters;
+    this.filters = this.dataTableConfig[this.activetabIndex].config.filters;
     this.initSort();
     this.filter();
   }


### PR DESCRIPTION
Fixes #551

Parallèlement, la méthode `clearFilters` était appelée deux fois par `ngOnChanges` et `initDatatable`, j'ai donc supprimé son appel de `initDatatable` car `ngOnChanges` est déjà appelée au chargement.