### PR TITLE
frontend carto édition : affichage des sites et/ou groupes de sites

### DIFF
--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -441,7 +441,8 @@ export class MonitoringFormComponent implements OnInit {
     }
     this.objForm.patchValue({ geometry: null });
     this.initForm();
-    // });
+    // Force le rafraichissement des géométries de façon à ammender le layer avec la dernière données saisie
+    this.display_geometry();
   }
 
   /** Pour donner des valeurs par defaut si la valeur n'est pas définie
@@ -951,6 +952,7 @@ export class MonitoringFormComponent implements OnInit {
   }
 
   ngOnDestroy() {
+    this._geojsonService.removeAllFeatureGroup();
     this.objForm.patchValue({ geometry: null });
   }
 }

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -35,8 +35,9 @@ import { Location } from '@angular/common';
 import { FormService } from '../../services/form.service';
 import { Router } from '@angular/router';
 import { TOOLTIPMESSAGEALERT, TOOLTIPMESSAGEALERT_CHILD } from '../../constants/guard';
-import { GeoJSONService } from '../../services/geojson.service';
+import { GeoJSONService, DisplayMode } from '../../services/geojson.service';
 import { Utils } from '../../utils/utils';
+import { Popup } from '../../utils/popup';
 
 @Component({
   selector: 'pnx-monitoring-form',
@@ -116,7 +117,8 @@ export class MonitoringFormComponent implements OnInit {
     private _router: Router,
     private _geojsonService: GeoJSONService,
     private _location: Location,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private _popup: Popup
   ) {}
 
   ngOnInit() {
@@ -262,6 +264,7 @@ export class MonitoringFormComponent implements OnInit {
         const dynamicGroupsArray = this.objForm.get('dynamicGroups') as FormArray;
         if (dynamicGroupsArray) this.subscribeToDynamicGroupsChanges(dynamicGroupsArray);
         this.setDefaultFormValue();
+        this.display_geometry();
       });
   }
 
@@ -274,6 +277,66 @@ export class MonitoringFormComponent implements OnInit {
       .subscribe((length) => {
         this.hasDynamicGroups = length > 0;
       });
+  }
+
+  display_geometry() {
+    // Affichage des
+    let displayType: DisplayMode = 'info';
+    if (!this.obj.id) {
+      displayType = 'info_zoom';
+    }
+    if (!['sites_group', 'site'].includes(this.obj.objectType)) {
+      return;
+    }
+    if (this.obj.objectType == 'sites_group') {
+      this._geojsonService.getSitesGroupsGeometries(this.onEachFeatureGroupSite(), {}, displayType);
+    }
+    if (this.obj.objectType == 'site') {
+      // Get id_sites_group
+      const id_sites_group =
+        this.queryParams['id_sites_group'] || this.obj.properties['id_sites_group'];
+
+      // S'il y a un id_site group
+      // et qu'il est spécifié dans les parents_path
+      // Affichage
+      if (
+        id_sites_group &&
+        ('id_sites_group' in this.queryParams ||
+          (this.queryParams['parents_path'] || []).includes('sites_group'))
+      ) {
+        // Display sites group and sites
+        this._geojsonService.getSitesGroupsGeometriesWithSites(
+          this.onEachFeatureGroupSite(),
+          this.onEachFeatureSite(),
+          { id_sites_group: id_sites_group },
+          { id_sites_group: id_sites_group },
+          displayType
+        );
+      } else {
+        // Display site
+        this._geojsonService.getSitesGroupsChildGeometries(
+          this.onEachFeatureSite(),
+          {},
+          displayType
+        );
+      }
+    }
+  }
+  onEachFeatureSite() {
+    return (feature, layer) => {
+      const popup = this._popup.setSitePopup(this.obj.moduleCode, feature, {
+        parents_path: ['module', 'sites_group'],
+      });
+      layer.bindPopup(popup);
+    };
+  }
+  onEachFeatureGroupSite() {
+    return (feature, layer) => {
+      const popup = this._popup.setSiteGroupPopup(this.obj.moduleCode, feature, {
+        parents_path: ['module', 'sites_group'],
+      });
+      layer.bindPopup(popup);
+    };
   }
 
   /** pour réutiliser des paramètres déjà saisis */

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -158,6 +158,17 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
         if (this.parentsPath.includes('sites_group')) {
           this.siteGroupIdParent = data.site.id_sites_group;
         }
+        // if (this.siteGroupIdParent) {
+        //   // Quand il y a un group de site défini affichage du groupes de sites
+        //   //  et autre sites associés pour avoir des repères
+        //   this.geojsonService.getSitesGroupsGeometriesWithSites(
+        //     this.onEachFeatureSite(),
+        //     this.onEachFeatureSite(),
+        //     { id_sites_group: this.siteGroupIdParent },
+        //     { id_sites_group: this.siteGroupIdParent },
+        //     true
+        //   );
+        // }
 
         // ajout des propriétés spécifiques au type de site
         // dans l'objet MonitoringObject

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -241,6 +241,7 @@ export class GeoJSONService {
   removeFeatureGroup(feature: L.FeatureGroup) {
     if (feature && this._mapService.map?.hasLayer(feature)) {
       this._mapService.map.removeLayer(feature);
+      this._mapService.layerControl.removeLayer(feature);
     }
   }
 
@@ -322,12 +323,24 @@ export class GeoJSONService {
     this._mapService.removeAllLayers(this._mapService.map, this._mapService.fileLayerFeatureGroup);
   }
 
-  private resolveMode(mode: DisplayMode, layerNameIfInfo: string): LayerModeConfig {
+  /**
+   * Détermine la configuration du mode d'affichage d'un layer.
+   *
+   * @param mode - Type d'affichage demandé ("info", "info_zoom" ou "main")
+   * @param layerName - Nom du layer concerné (utilisé uniquement pour les modes info)
+   * @returns Un objet LayerModeConfig décrivant le comportement attendu
+   */
+
+  private resolveMode(mode: DisplayMode, layerName: string): LayerModeConfig {
+    // Modes "info" :
+    // - "info"      : Affichage dans le layer Control pas de zoom automatique
+    // - "info_zoom" : Affichage dans le layer Control zoom forcé sur l'entité cliquée
+    // - "main"      : Affichage en tant qu'élement principal de la carte zoom forcé sur l'entité cliquée
     if (mode === 'info' || mode === 'info_zoom') {
       return {
-        layerName: layerNameIfInfo,
+        layerName: layerName,
         zoom: mode === 'info_zoom',
-        clearExisting: false, // en mode info on garde les données
+        clearExisting: this.testLayerControlExists(layerName), // test si le layer est déjà présent dans Layercontrol
       };
     }
     return {
@@ -335,5 +348,21 @@ export class GeoJSONService {
       zoom: true,
       clearExisting: true, // en "main", on nettoye les données à chaque appel
     };
+  }
+
+  /**
+   * Vérifie si un layer  (défini par son nom)  existe déjà
+   * dans le LayerControl de la carte.
+   *
+   * @param layerName - Nom du layer à rechercher
+   * @returns true si un overlay du LayerControl possède ce nom, sinon false
+   */
+  private testLayerControlExists(layerName: string): boolean {
+    const layers = this._mapService.layerControl?.['_layers'] ?? [];
+    const overlayNames = new Set(layers.filter((o: any) => o?.overlay).map((o: any) => o?.name));
+    if (overlayNames.has(layerName)) {
+      return true;
+    }
+    return false;
   }
 }

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -19,6 +19,24 @@ const defaultSiteGroupStyle = {
   zIndex: 20,
 };
 
+const defaultSiteGroupStyleInfo = {
+  fillColor: '#a48aa4ff',
+  fillOpacity: 0.4,
+  color: '#a48aa4ff',
+  opacity: 0.7,
+  weight: 2,
+  fill: true,
+  zIndex: 200,
+};
+
+const defaultSiteStyleInfo = {
+  fillColor: '#a48aa4ff',
+  fillOpacity: 0.2,
+  color: '#fa3efaff',
+  opacity: 0.4,
+  zIndex: 300,
+};
+
 const selectedSiteGroupStyle = {
   fillColor: '#ac0000',
   fillOpacity: 0.5,
@@ -34,6 +52,17 @@ const selectedSiteStyle = {
   color: 'red',
   zIndex: 30,
 };
+
+const NAME_LAYER_SITE: string = 'Sites';
+const NAME_LAYER_GRP_SITE: string = 'Groupe de sites';
+
+export type DisplayMode = 'main' | 'info' | 'info_zoom';
+
+interface LayerModeConfig {
+  layerName: string | null;
+  zoom: boolean;
+  clearExisting: boolean;
+}
 
 @Injectable()
 export class GeoJSONService {
@@ -68,69 +97,131 @@ export class GeoJSONService {
     sitesOnEachFeature: Function,
     paramsSitesGroup = {},
     paramsSite = {},
+    mode: DisplayMode = 'main',
     sitesGroupstyle?,
     sitesStyle?
   ) {
+    const cfgGroup = this.resolveMode(mode, NAME_LAYER_GRP_SITE);
+    const cfgSite = this.resolveMode(mode, NAME_LAYER_SITE);
+
+    const effectiveGroupStyle =
+      sitesGroupstyle ??
+      (mode === 'info' || mode === 'info_zoom' ? defaultSiteGroupStyleInfo : defaultSiteGroupStyle);
+
+    const effectiveSiteStyle =
+      sitesStyle ?? (mode === 'info' || mode === 'info_zoom' ? defaultSiteStyleInfo : undefined);
+
     return forkJoin({
       sitesGroup: this._sites_group_service.get_geometries(paramsSitesGroup),
       sites: this._sites_service.get_geometries(paramsSite),
     }).subscribe((data) => {
       this.geojsonSitesGroups = data['sitesGroup'];
-      this.removeFeatureGroup(this.sitesGroupFeatureGroup);
+
+      if (cfgGroup.clearExisting) this.removeFeatureGroup(this.sitesGroupFeatureGroup);
+      if (cfgSite.clearExisting) this.removeFeatureGroup(this.sitesFeatureGroup);
+
       this.sitesGroupFeatureGroup = this.setMapData(
         data['sitesGroup'],
         sitesGroupOnEachFeature,
-        sitesGroupstyle || defaultSiteGroupStyle
+        cfgGroup.layerName,
+        cfgGroup.zoom,
+        effectiveGroupStyle
       );
-      this.removeFeatureGroup(this.sitesFeatureGroup);
-      this.sitesFeatureGroup = this.setMapData(data['sites'], sitesOnEachFeature, sitesStyle);
+      this.sitesFeatureGroup = this.setMapData(
+        data['sites'],
+        sitesOnEachFeature,
+        cfgSite.layerName,
+        false, // Toujours false car on zoom sur le groupe de site
+        effectiveSiteStyle
+      );
     });
   }
 
-  getSitesGroupsGeometries(onEachFeature: Function, params = {}, style?) {
+  getSitesGroupsGeometries(
+    onEachFeature: Function,
+    params = {},
+    mode: DisplayMode = 'main',
+    style?
+  ) {
+    const cfg = this.resolveMode(mode, NAME_LAYER_GRP_SITE);
+    const effectiveStyle =
+      style ??
+      (mode === 'info' || mode === 'info_zoom' ? defaultSiteGroupStyleInfo : defaultSiteGroupStyle);
+
     this._sites_group_service
       .get_geometries(params)
       .subscribe((data: GeoJSON.FeatureCollection) => {
         this.geojsonSitesGroups = data;
-        this.removeFeatureGroup(this.sitesGroupFeatureGroup);
+        if (cfg.clearExisting) {
+          this.removeFeatureGroup(this.sitesGroupFeatureGroup);
+        }
+
         this.sitesGroupFeatureGroup = this.setMapData(
           data,
           onEachFeature,
-          style || defaultSiteGroupStyle
+          cfg.layerName,
+          cfg.zoom,
+          effectiveStyle
         );
       });
   }
 
-  getSitesGroupsChildGeometries(onEachFeature: Function, params = {}, style?) {
+  getSitesGroupsChildGeometries(
+    onEachFeature: Function,
+    params = {},
+    mode: DisplayMode = 'main',
+    style?
+  ) {
+    const cfg = this.resolveMode(mode, NAME_LAYER_SITE);
+    const effectiveStyle =
+      style ?? (mode === 'info' || mode === 'info_zoom' ? defaultSiteStyleInfo : undefined);
+
     this._sites_service.get_geometries(params).subscribe((data: GeoJSON.FeatureCollection) => {
-      this.removeFeatureGroup(this.sitesFeatureGroup);
-      this.sitesFeatureGroup = this.setMapData(data, onEachFeature, style);
+      if (cfg.clearExisting) {
+        this.removeFeatureGroup(this.sitesFeatureGroup);
+      }
+      this.sitesFeatureGroup = this.setMapData(
+        data,
+        onEachFeature,
+        cfg.layerName,
+        cfg.zoom,
+        effectiveStyle
+      );
     });
   }
 
-  setGeomSiteGroupFromExistingObject(geom) {
-    this.sitesGroupFeatureGroup = this.setMapData(geom, () => {});
-  }
+  // setGeomSiteGroupFromExistingObject(geom, name:boolean = false) {
+  //   this.sitesGroupFeatureGroup = this.setMapData(geom, () => {}, name ? NAME_LAYER_SITE : null, null);
+  // }
 
   setMapData(
     geojson: GeoJSON.Geometry | GeoJSON.FeatureCollection,
     onEachFeature: Function,
+    layerName: string | null,
+    zoom: boolean = true,
     style?
-  ) {
+  ): L.FeatureGroup | undefined {
     const map = this._mapService.getMap();
     if (geojson['features'] == null) {
       return undefined;
     }
+
     const layer: L.Layer = this._mapService.createGeojson(geojson, false, onEachFeature, style);
     const featureGroup = new L.FeatureGroup();
-    this._mapService.map.addLayer(featureGroup);
     featureGroup.addLayer(layer);
-    map.fitBounds(featureGroup.getBounds());
+    this._mapService.map.addLayer(featureGroup);
 
+    if (layerName) {
+      this._mapService.layerControl.addOverlay(featureGroup, layerName);
+    }
+    if (zoom) {
+      map.fitBounds(featureGroup.getBounds());
+    }
     return featureGroup;
   }
 
   setMapDataWithFeatureGroup(featureGroup: L.FeatureGroup[]) {
+    // ?????? usage
     for (const layer of featureGroup) {
       if (layer != undefined) {
         this._mapService.map.addLayer(layer);
@@ -144,27 +235,28 @@ export class GeoJSONService {
 
   setMapBeforeEdit(geom) {
     this.currentLayer = null;
-    this.setMapData(geom, () => {});
+    this.setMapData(geom, () => {}, null);
   }
 
   removeFeatureGroup(feature: L.FeatureGroup) {
-    if (feature && this._mapService.map) {
+    if (feature && this._mapService.map?.hasLayer(feature)) {
       this._mapService.map.removeLayer(feature);
     }
   }
 
   onEachFeature() {}
 
-  filterSitesGroups(siteGroupId: number) {
-    if (this.geojsonSitesGroups !== undefined) {
-      const features = this.geojsonSitesGroups.features.filter(
-        (feature) => feature.properties.id_sites_group == siteGroupId
-      );
-      this.geojsonSitesGroups.features = features;
-      this.removeFeatureGroup(this.sitesGroupFeatureGroup);
-      this.setMapData(this.geojsonSitesGroups, this.onEachFeature, defaultSiteGroupStyle);
-    }
-  }
+  // Jamais appelé
+  // filterSitesGroups(siteGroupId: number) {
+  //   if (this.geojsonSitesGroups !== undefined) {
+  //     const features = this.geojsonSitesGroups.features.filter(
+  //       (feature) => feature.properties.id_sites_group == siteGroupId
+  //     );
+  //     this.geojsonSitesGroups.features = features;
+  //     this.removeFeatureGroup(this.sitesGroupFeatureGroup);
+  //     this.setMapData(this.geojsonSitesGroups, this.onEachFeature, null, defaultSiteGroupStyle);
+  //   }
+  // }
 
   selectSitesGroupLayer(id: number, zoom: boolean) {
     this.sitesGroupFeatureGroup.eachLayer((layer) => {
@@ -222,10 +314,26 @@ export class GeoJSONService {
     });
     for (const featureGroup of listFeatureGroup) {
       this.removeFeatureGroup(featureGroup);
+      this._mapService.layerControl.removeLayer(featureGroup);
     }
   }
 
   removeFileLayerGroup() {
     this._mapService.removeAllLayers(this._mapService.map, this._mapService.fileLayerFeatureGroup);
+  }
+
+  private resolveMode(mode: DisplayMode, layerNameIfInfo: string): LayerModeConfig {
+    if (mode === 'info' || mode === 'info_zoom') {
+      return {
+        layerName: layerNameIfInfo,
+        zoom: mode === 'info_zoom',
+        clearExisting: false, // en mode info on garde les données
+      };
+    }
+    return {
+      layerName: null,
+      zoom: true,
+      clearExisting: true, // en "main", on nettoye les données à chaque appel
+    };
   }
 }


### PR DESCRIPTION
Affichage des sites et/ou groupes de sites lors de la création ou l'édition d'un site ou d'un groupe de site

<img width="947" height="498" alt="image" src="https://github.com/user-attachments/assets/0ba7177a-0018-4f9a-a2bc-380cc2a8a879" />


- Affichage cartographique des autres objets lors de l'édition d'un site ou d'un groupe de site (activables/désactivables via le gestionnaire de couches de Leaflet) :
  - site : affichage des sites du sous-module
  - groupe de sites : affichage des groupes de sites du sous-module
  - site associé à un groupe de sites : affichage du groupe de sites et des sites associés

<img width="1909" height="948" alt="Capture d&#39;écran 2026-02-02 122045" src="https://github.com/user-attachments/assets/d24abe5f-c85c-42f9-8190-61b355d14fca" />