### PR TITLE
feat: désactivation des sites

### DIFF
--- a/backend/gn_module_monitoring/config/generic/site.json
+++ b/backend/gn_module_monitoring/config/generic/site.json
@@ -5,6 +5,9 @@
   "label": "Site",
   "label_list": "Sites",
   "genre": "M",
+  "filters": {
+    "active": true
+  },
   "geom_field_name": "geom",
   "uuid_field_name": "uuid_base_site",
   "geometry_type": [
@@ -19,6 +22,7 @@
     "id_inventor",
     "first_use_date",
     "last_visit",
+    "active",
     "nb_visits",
     "altitude_min",
     "altitude_max",
@@ -29,6 +33,7 @@
     "base_site_code",
     "last_visit",
     "id_inventor",
+    "active",
     "nb_visits",
     "types_site",
     "nb_individuals"
@@ -120,6 +125,13 @@
       "nullDefault": true,
       "definition": "Permet de n'avoir que les types de site lié au module",
       "designStyle": "bootstrap"
+    },
+    "active": {
+      "type_widget": "bool_checkbox",
+      "attribut_label": "Actif",
+      "required": true,
+      "default": true,
+      "value": true
     }
   }
 }

--- a/backend/gn_module_monitoring/routes/monitoring.py
+++ b/backend/gn_module_monitoring/routes/monitoring.py
@@ -240,13 +240,17 @@ def create_object_api(module_code, object_type, id):
     post_data = dict(request.get_json())
 
     # prevent visit creation if site is inactive
-    if object_type == 'visit':
-        id_base_site = post_data['properties']['id_base_site']
+    if object_type == "visit":
+        id_base_site = post_data["properties"]["id_base_site"]
         query = select(TBaseSites.active).where(TBaseSites.id_base_site == id_base_site)
         is_active = DB.session.scalar(query)
 
         if not is_active:
-            raise GeoNatureError("MONITORING: create_object_api {} : site n°{} is inactive".format(object_type, str(id_base_site)))
+            raise GeoNatureError(
+                "MONITORING: create_object_api {} : site n°{} is inactive".format(
+                    object_type, str(id_base_site)
+                )
+            )
 
     # get_config(module_code, force=True)
     return create_or_update_object_api(module_code, object_type, id)

--- a/backend/gn_module_monitoring/routes/monitoring.py
+++ b/backend/gn_module_monitoring/routes/monitoring.py
@@ -24,8 +24,10 @@ from geonature.core.gn_permissions.decorators import check_cruved_scope
 from geonature.core.gn_commons.models.base import TModules
 from geonature.core.gn_permissions.models import TObjects
 from geonature.core.imports.models import Destination
+from gn_module_monitoring.monitoring.models import TBaseSites
 
 from geonature.utils.env import DB, ROOT_DIR
+from geonature.utils.errors import GeoNatureError
 import geonature.utils.filemanager as fm
 
 from gn_module_monitoring.blueprint import blueprint
@@ -236,6 +238,16 @@ def update_object_api(scope, module_code, object_type, id):
 @json_resp
 def create_object_api(module_code, object_type, id):
     post_data = dict(request.get_json())
+
+    # prevent visit creation if site is inactive
+    if object_type == 'visit':
+        id_base_site = post_data['properties']['id_base_site']
+        query = select(TBaseSites.active).where(TBaseSites.id_base_site == id_base_site)
+        is_active = DB.session.scalar(query)
+
+        if not is_active:
+            raise GeoNatureError("MONITORING: create_object_api {} : site n°{} is inactive".format(object_type, str(id_base_site)))
+
     # get_config(module_code, force=True)
     return create_or_update_object_api(module_code, object_type, id)
 

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -167,7 +167,7 @@
                   <ng-template #chooseProtocolPopup>
                     <option-list-btn
                       placeholder="Sélectionner le protocole"
-                      label="{{ 'Monitoring.Sites.addVisit' | translate }}"
+                      label="{{ row.active ? 'Monitoring.Sites.addVisit'  : 'Monitoring.Sites.inactiveSite' | translate }}"
                       [iconOrButton]="icon"
                       [canCreateChild]="canCreateChild && row.active"
                       [item]="row"

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.html
@@ -169,7 +169,7 @@
                       placeholder="Sélectionner le protocole"
                       label="{{ 'Monitoring.Sites.addVisit' | translate }}"
                       [iconOrButton]="icon"
-                      [canCreateChild]="canCreateChild"
+                      [canCreateChild]="canCreateChild && row.active"
                       [item]="row"
                       (onDeployed)="addChildrenVisit(row)"
                       (onSaved)="saveOptionChild($event)"

--- a/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
+++ b/frontend/app/components/monitoring-datatable-g/monitoring-datatable-g.component.ts
@@ -252,9 +252,10 @@ export class MonitoringDatatableGComponent implements OnInit {
         this.canCreateChild = this.permission[objectTypeChild].canCreate ? true : false;
         // Cas du module générique (moduleCode = 'generic')
         //  Il n'y a pas de permissions pour les visites,
-        //  elles sont créées dans le contexte d'un module
-        // Par défaut : création autorisée mais seul les modules où l'utilisateur a le droit de créer des visites
-        //  seront afficher dans le menu déroulant
+        //  elles sont créées dans le contexte d'un module.
+        // Par défaut : création autorisée sauf pour les sites inactifs
+        //  mais seuls les modules où l'utilisateur a le droit de créer des visites*
+        //  seront affichés dans le menu déroulant
         if (this.moduleCode === 'generic') this.canCreateChild = true;
         break;
       case 'individual':

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.html
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.html
@@ -45,7 +45,7 @@
   parentPath="site"
 >
   <!-- Bouton pour ajouter une visite
-      dans le module generic le bouton est toujours actif c'est la liste des modules disponibles à l'utilisateur qui determinera les permissions
+      dans le module generic le bouton est toujours actif, sauf si le site est désactivé, c'est la liste des modules disponibles à l'utilisateur qui determinera les permissions
       Sinon dans le contexte d'un sous module on verifie la permission sur VISITES -->
   <option-list-btn
     add-button

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.html
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.html
@@ -54,8 +54,6 @@
     [optionList]="modules"
     (onDeployed)="getModules()"
     (onSaved)="addNewVisit($event)"
-    [canCreateChild]="
-      moduleCode === 'generic' ? true : currentPermission?.MONITORINGS_VISITES?.canCreate > 0
-    "
+    [canCreateChild] = "canCreateVisit"
   ></option-list-btn>
 </pnx-monitoring-datatable-g>

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -257,6 +257,13 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
     }
   }
 
+  get canCreateVisit () {
+    if (this.obj.properties.active === false) { // is the site inactive?
+      return false;
+    }
+    return this.moduleCode === 'generic'? true : !!this.currentPermission?.MONITORINGS_VISITES?.canCreate === true; // check permission
+  }
+
   addNewVisit($event: SelectObject) {
     const moduleCode = $event.id;
     //create_object/cheveches_sites_group/visit?id_base_site=47

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -257,11 +257,14 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
     }
   }
 
-  get canCreateVisit () {
-    if (this.obj.properties.active === false) { // is the site inactive?
+  get canCreateVisit() {
+    if (this.obj.properties.active === false) {
+      // is the site inactive?
       return false;
     }
-    return this.moduleCode === 'generic'? true : !!this.currentPermission?.MONITORINGS_VISITES?.canCreate === true; // check permission
+    return this.moduleCode === 'generic'
+      ? true
+      : !!this.currentPermission?.MONITORINGS_VISITES?.canCreate === true; // check permission
   }
 
   addNewVisit($event: SelectObject) {

--- a/frontend/app/interfaces/geom.ts
+++ b/frontend/app/interfaces/geom.ts
@@ -45,6 +45,7 @@ export interface ISite extends IGeomObject {
   id_sites_group: number;
   id_inventor: string[];
   inventor: string[];
+  active: boolean;
 }
 
 export interface ISiteField extends Omit<ISite, 'types_site'> {

--- a/frontend/assets/i18n/fr.json
+++ b/frontend/assets/i18n/fr.json
@@ -46,7 +46,8 @@
             "NoModules" : "Aucun protocole n'est disponible pour ce type de site"
         },
         "Sites" : {
-            "addVisit" : "Ajouter une visite" 
+            "addVisit" : "Ajouter une visite",
+            "inactiveSite" : "Site inactif"
         },
         "Actions" : {
             "Done" : " effectuée",


### PR DESCRIPTION
Fixes #533

Nécessite la PR [3897](https://github.com/PnX-SI/GeoNature/pull/3897) de GeoNature

- filtre par défaut sur les sites actifs (nécessite la PR #552)
- désactivation du bouton de création d'un site inactif sur sa page détail
- désactivation des icônes de création des sites inactifs sur la page d'un module ou d'un groupe de sites + modification du tooltip pour expliciter cette désactivation
- empêchement backend de création d'une visite pour un site inactif