### PR TITLE
Corretion changement de pages - Update monitoring-sitesgroups-detail.component.ts

### DIFF
--- a/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
@@ -256,7 +256,7 @@ export class MonitoringSitesgroupsDetailComponent
     // Tableau
     const fieldsConfig = this._configService.schema(this.moduleCode, 'site');
     this._sitesGroupService
-      .getSitesChildResolved(1, this.limit, sitesParams, fieldsConfig)
+      .getSitesChildResolved(page, this.limit, sitesParams, fieldsConfig)
       .subscribe((data: IPaginated<ISite>) => {
         const siteList = data.items;
         this.rows = siteList;


### PR DESCRIPTION
Correction d'un bug dans le changement de pages des sites lorsqu'ils sont consultés à partir de l'entrée Groupe de sites. Le nombre de sites est limité à 10 par page. Sur les groupes de sites avec plus de 10 sites, il n'était pas possible de passer aux pages suivantes. Il restait bloqué sur la page 1.