### PR TITLE
Feat/autres objets fiches detail

### DIFF
--- a/frontend/app/class/monitoring-object-base.ts
+++ b/frontend/app/class/monitoring-object-base.ts
@@ -414,7 +414,9 @@ export class MonitoringObjectBase {
       this.parentsPath.pop();
       const parent = new this.myClass(this.moduleCode, parentType, null, this._objService);
       const parentId = this.properties[parent.idFieldName()];
-      if (parentType === 'module') {
+      // pas de parent renseigné (un site hors groupe) : retour sur la liste du
+      // type courant, pas sur celle d'un parent que l'objet n'avait pas
+      if (parentType === 'module' || !parentId) {
         this._objService.navigate('object', this.moduleCode, this.objectType, null, {
           parents_path: this.parentsPath,
         });

--- a/frontend/app/components/monitoring-form/monitoring-form.component.ts
+++ b/frontend/app/components/monitoring-form/monitoring-form.component.ts
@@ -570,7 +570,11 @@ export class MonitoringFormComponent implements OnInit {
 
   onCancelEdit() {
     this.bEditChange.emit(false);
-    this._location.back();
+    // reculer n'a de sens que si l'édition vient d'une navigation ; sur une fiche
+    // détail elle n'est qu'un changement d'état
+    if (!this.obj.id || this._route.snapshot.params['edit'] === 'true') {
+      this._location.back();
+    }
     if (this.obj.id) {
       this.obj.geometry == null
         ? this._geojsonService.setMapDataWithFeatureGroup([this._geojsonService.sitesFeatureGroup])

--- a/frontend/app/components/monitoring-map/monitoring-map.component.ts
+++ b/frontend/app/components/monitoring-map/monitoring-map.component.ts
@@ -179,18 +179,16 @@ export class MonitoringMapComponent implements OnInit {
 
   /** sites et groupes de sites du sous-module, en couches "info" */
   displayOtherObjects(idBaseSite: number) {
-    const { id_base_site, ...moduleSiteParams } = this.listService.getPrefilterByType('site');
-
     this._geojsonService.getSitesGroupsChildGeometries(
       this.onEachFeatureSite(this.buildQueryParams('site')),
-      moduleSiteParams,
+      { types_site: this._configService.moduleTypesSite(this.obj.moduleCode) },
       'info_hidden',
       undefined,
       { property: 'id_base_site', value: idBaseSite }
     );
     this._geojsonService.getSitesGroupsGeometries(
       this.onEachFeatureGroupSite(this.buildQueryParams('sites_group')),
-      this.listService.getPrefilterByType('sites_group'),
+      {},
       'info_hidden'
     );
   }

--- a/frontend/app/components/monitoring-map/monitoring-map.component.ts
+++ b/frontend/app/components/monitoring-map/monitoring-map.component.ts
@@ -146,6 +146,10 @@ export class MonitoringMapComponent implements OnInit {
         this.onEachFeatureSite(this.buildQueryParams('site')),
         params
       );
+      // couche principale restreinte à un site, on propose les autres en repère
+      if (params['id_base_site'] !== undefined) {
+        this.displayOtherObjects(params['id_base_site']);
+      }
     } else if (displayObject == 'sites_group') {
       const params = {
         ...this.listService.getPrefilterByType(displayObject),
@@ -171,6 +175,24 @@ export class MonitoringMapComponent implements OnInit {
         paramsSite
       );
     }
+  }
+
+  /** sites et groupes de sites du sous-module, en couches "info" */
+  displayOtherObjects(idBaseSite: number) {
+    const { id_base_site, ...moduleSiteParams } = this.listService.getPrefilterByType('site');
+
+    this._geojsonService.getSitesGroupsChildGeometries(
+      this.onEachFeatureSite(this.buildQueryParams('site')),
+      moduleSiteParams,
+      'info_hidden',
+      undefined,
+      { property: 'id_base_site', value: idBaseSite }
+    );
+    this._geojsonService.getSitesGroupsGeometries(
+      this.onEachFeatureGroupSite(this.buildQueryParams('sites_group')),
+      this.listService.getPrefilterByType('sites_group'),
+      'info_hidden'
+    );
   }
 
   buildQueryParams(displayObject: string) {

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -229,7 +229,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   displayOtherObjects(idBaseSite: number) {
     this.geojsonService.getSitesGroupsChildGeometries(
       this.onEachFeatureSite(),
-      {},
+      { types_site: this._configService.moduleTypesSite(this.moduleCode) },
       'info_hidden',
       undefined,
       { property: 'id_base_site', value: idBaseSite }
@@ -337,7 +337,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
   }
 
   ngOnDestroy() {
-    this.geojsonService.removeFeatureGroup(this.geojsonService.sitesFeatureGroup);
+    this.geojsonService.removeAllFeatureGroup();
     this._formService.changeCurrentEditMode(false);
     this._formService.changeFormMapObj({
       frmGp: null,

--- a/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
+++ b/frontend/app/components/monitoring-sites-detail/monitoring-sites-detail.component.ts
@@ -131,6 +131,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
           this.geojsonService.getSitesGroupsChildGeometries(this.onEachFeatureSite(), {
             id_base_site: siteId,
           });
+          this.displayOtherObjects(siteId);
 
           // Récupération des données et des configurations
           //  pour le site et les visites associées
@@ -214,6 +215,26 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
       const popup = this._popup.setSitePopup(this.moduleCode, feature, {});
       layer.bindPopup(popup);
     };
+  }
+
+  onEachFeatureGroupSite() {
+    return (feature, layer) => {
+      const popup = this._popup.setSiteGroupPopup(this.moduleCode, feature, {});
+      layer.bindPopup(popup);
+    };
+  }
+
+  /** sites et groupes du sous-module en couches "info" : leur popup passe d'un site
+      à l'autre sans repasser par la liste, qui réinitialise le zoom */
+  displayOtherObjects(idBaseSite: number) {
+    this.geojsonService.getSitesGroupsChildGeometries(
+      this.onEachFeatureSite(),
+      {},
+      'info_hidden',
+      undefined,
+      { property: 'id_base_site', value: idBaseSite }
+    );
+    this.geojsonService.getSitesGroupsGeometries(this.onEachFeatureGroupSite(), {}, 'info_hidden');
   }
 
   getVisits(page: number, filters: JsonData) {
@@ -303,6 +324,7 @@ export class MonitoringSitesDetailComponent extends MonitoringGeomComponent impl
       this.geojsonService.getSitesGroupsChildGeometries(this.onEachFeatureSite(), {
         id_base_site: this.site.id_base_site,
       });
+      this.displayOtherObjects(this.site.id_base_site);
     }
     this.bEdit = event;
     if (this.bEdit) {

--- a/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
@@ -222,6 +222,7 @@ export class MonitoringSitesgroupsDetailComponent
         this.baseFilters,
         sitesParams
       );
+      this.displayOtherObjects();
     }
 
     this.bEdit = event;
@@ -272,6 +273,27 @@ export class MonitoringSitesgroupsDetailComponent
       this.onEachFeatureSite(),
       this.baseFilters,
       sitesParams
+    );
+    this.displayOtherObjects();
+  }
+
+  /** autres groupes du sous-module et sites hors du groupe, en couches "info" : la
+      couche principale dessine déjà le groupe courant et ses sites */
+  displayOtherObjects() {
+    const exclude = { property: 'id_sites_group', value: this.siteGroupId };
+    this._geojsonService.getSitesGroupsGeometries(
+      this.onEachFeatureGroupSite(),
+      {},
+      'info_hidden',
+      undefined,
+      exclude
+    );
+    this._geojsonService.getSitesGroupsChildGeometries(
+      this.onEachFeatureSite(),
+      {},
+      'info_hidden',
+      undefined,
+      exclude
     );
   }
 

--- a/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
+++ b/frontend/app/components/monitoring-sitesgroups-detail/monitoring-sitesgroups-detail.component.ts
@@ -290,7 +290,7 @@ export class MonitoringSitesgroupsDetailComponent
     );
     this._geojsonService.getSitesGroupsChildGeometries(
       this.onEachFeatureSite(),
-      {},
+      { types_site: this._configService.moduleTypesSite(this.moduleCode) },
       'info_hidden',
       undefined,
       exclude

--- a/frontend/app/services/config.service.ts
+++ b/frontend/app/services/config.service.ts
@@ -229,6 +229,13 @@ export class ConfigService {
     return this._config;
   }
 
+  /** identifiants des types de site du sous-module, seul filtre que la route
+   * geometries n'applique pas d'elle-même à partir du module de l'URL */
+  moduleTypesSite(moduleCode: string): string[] {
+    moduleCode = moduleCode || 'generic';
+    return Object.keys(this._config[moduleCode]?.['module']?.['types_site'] ?? {});
+  }
+
   cache() {
     return this._config;
   }

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -266,10 +266,11 @@ export class GeoJSONService {
         // createOrderedGeojson l'a déjà ajoutée à la carte, la retirer pour la
         // laisser à cocher
         map.removeLayer(featureGroup);
-      } else if (zoom) {
-        map.fitBounds(featureGroup.getBounds());
       }
     });
+    if (zoom) {
+      map.fitBounds(featureGroup.getBounds());
+    }
 
     return featureGroup;
   }
@@ -471,7 +472,9 @@ export class GeoJSONService {
       return {
         layerName: layerName,
         zoom: mode === 'info_zoom',
-        visible: this.userLayerVisibility[layerName] ?? mode !== 'info_hidden',
+        // seule la couche "à cocher" garde le choix de l'utilisateur ; en "info" et
+        // "info_zoom" la couche est un repère que le formulaire attend à l'écran
+        visible: mode !== 'info_hidden' || (this.userLayerVisibility[layerName] ?? false),
       };
     }
     return {

--- a/frontend/app/services/geojson.service.ts
+++ b/frontend/app/services/geojson.service.ts
@@ -54,14 +54,20 @@ const selectedSiteStyle = {
 };
 
 const NAME_LAYER_SITE: string = 'Sites';
-const NAME_LAYER_GRP_SITE: string = 'Groupe de sites';
+const NAME_LAYER_GRP_SITE: string = 'Groupes de sites';
 
-export type DisplayMode = 'main' | 'info' | 'info_zoom';
+export type DisplayMode = 'main' | 'info' | 'info_zoom' | 'info_hidden';
+
+/** entités déjà dessinées par la couche principale, à ne pas redessiner en "info" */
+export interface ExcludedFeatures {
+  property: string;
+  value?: number | string;
+}
 
 interface LayerModeConfig {
   layerName: string | null;
   zoom: boolean;
-  clearExisting: boolean;
+  visible: boolean;
 }
 
 @Injectable()
@@ -70,6 +76,12 @@ export class GeoJSONService {
   geojsonSites: GeoJSON.FeatureCollection;
   sitesGroupFeatureGroup: L.FeatureGroup;
   sitesFeatureGroup: L.FeatureGroup;
+  infoFeatureGroups: { [layerName: string]: L.FeatureGroup } = {};
+  // cases cochées par l'utilisateur, captées sur les événements du layer Control ;
+  // l'état de la carte ne suffit pas, il change aussi quand la page change
+  private userLayerVisibility: { [layerName: string]: boolean } = {};
+  private watchedMap: L.Map;
+  private ownLayerChanges = 0;
   currentLayer: any = null;
 
   constructor(
@@ -87,6 +99,14 @@ export class GeoJSONService {
   removeAllLayers() {
     this.removeFeatureGroup(this.sitesGroupFeatureGroup);
     this.removeFeatureGroup(this.sitesFeatureGroup);
+    this.forgetInfoFeatureGroups();
+  }
+
+  private forgetInfoFeatureGroups() {
+    Object.values(this.infoFeatureGroups).forEach((featureGroup) =>
+      this.removeFeatureGroup(featureGroup)
+    );
+    this.infoFeatureGroups = {};
   }
 
   /*
@@ -105,11 +125,9 @@ export class GeoJSONService {
     const cfgSite = this.resolveMode(mode, NAME_LAYER_SITE);
 
     const effectiveGroupStyle =
-      sitesGroupstyle ??
-      (mode === 'info' || mode === 'info_zoom' ? defaultSiteGroupStyleInfo : defaultSiteGroupStyle);
+      sitesGroupstyle ?? (mode !== 'main' ? defaultSiteGroupStyleInfo : defaultSiteGroupStyle);
 
-    const effectiveSiteStyle =
-      sitesStyle ?? (mode === 'info' || mode === 'info_zoom' ? defaultSiteStyleInfo : undefined);
+    const effectiveSiteStyle = sitesStyle ?? (mode !== 'main' ? defaultSiteStyleInfo : undefined);
 
     return forkJoin({
       sitesGroup: this._sites_group_service.get_geometries(paramsSitesGroup),
@@ -117,22 +135,34 @@ export class GeoJSONService {
     }).subscribe((data) => {
       this.geojsonSitesGroups = data['sitesGroup'];
 
-      if (cfgGroup.clearExisting) this.removeFeatureGroup(this.sitesGroupFeatureGroup);
-      if (cfgSite.clearExisting) this.removeFeatureGroup(this.sitesFeatureGroup);
+      this.replaceFeatureGroup(mode, 'sitesGroupFeatureGroup', cfgGroup.layerName);
+      this.replaceFeatureGroup(mode, 'sitesFeatureGroup', cfgSite.layerName);
 
-      this.sitesGroupFeatureGroup = this.setMapData(
-        data['sitesGroup'],
-        sitesGroupOnEachFeature,
-        cfgGroup.layerName,
-        cfgGroup.zoom,
-        effectiveGroupStyle
+      this.storeFeatureGroup(
+        this.setMapData(
+          data['sitesGroup'],
+          sitesGroupOnEachFeature,
+          cfgGroup.layerName,
+          cfgGroup.zoom,
+          effectiveGroupStyle,
+          cfgGroup.visible
+        ),
+        mode,
+        'sitesGroupFeatureGroup',
+        cfgGroup.layerName
       );
-      this.sitesFeatureGroup = this.setMapData(
-        data['sites'],
-        sitesOnEachFeature,
-        cfgSite.layerName,
-        false, // Toujours false car on zoom sur le groupe de site
-        effectiveSiteStyle
+      this.storeFeatureGroup(
+        this.setMapData(
+          data['sites'],
+          sitesOnEachFeature,
+          cfgSite.layerName,
+          false, // Toujours false car on zoom sur le groupe de site
+          effectiveSiteStyle,
+          cfgSite.visible
+        ),
+        mode,
+        'sitesFeatureGroup',
+        cfgSite.layerName
       );
     });
   }
@@ -141,27 +171,31 @@ export class GeoJSONService {
     onEachFeature: Function,
     params = {},
     mode: DisplayMode = 'main',
-    style?
+    style?,
+    exclude?: ExcludedFeatures
   ) {
     const cfg = this.resolveMode(mode, NAME_LAYER_GRP_SITE);
     const effectiveStyle =
-      style ??
-      (mode === 'info' || mode === 'info_zoom' ? defaultSiteGroupStyleInfo : defaultSiteGroupStyle);
+      style ?? (mode !== 'main' ? defaultSiteGroupStyleInfo : defaultSiteGroupStyle);
 
     this._sites_group_service
       .get_geometries(params)
       .subscribe((data: GeoJSON.FeatureCollection) => {
         this.geojsonSitesGroups = data;
-        if (cfg.clearExisting) {
-          this.removeFeatureGroup(this.sitesGroupFeatureGroup);
-        }
+        this.replaceFeatureGroup(mode, 'sitesGroupFeatureGroup', cfg.layerName);
 
-        this.sitesGroupFeatureGroup = this.setMapData(
-          data,
-          onEachFeature,
-          cfg.layerName,
-          cfg.zoom,
-          effectiveStyle
+        this.storeFeatureGroup(
+          this.setMapData(
+            this.excludeFeatures(data, exclude),
+            onEachFeature,
+            cfg.layerName,
+            cfg.zoom,
+            effectiveStyle,
+            cfg.visible
+          ),
+          mode,
+          'sitesGroupFeatureGroup',
+          cfg.layerName
         );
       });
   }
@@ -170,23 +204,27 @@ export class GeoJSONService {
     onEachFeature: Function,
     params = {},
     mode: DisplayMode = 'main',
-    style?
+    style?,
+    exclude?: ExcludedFeatures
   ) {
     const cfg = this.resolveMode(mode, NAME_LAYER_SITE);
-    const effectiveStyle =
-      style ?? (mode === 'info' || mode === 'info_zoom' ? defaultSiteStyleInfo : undefined);
+    const effectiveStyle = style ?? (mode !== 'main' ? defaultSiteStyleInfo : undefined);
 
     this._sites_service.get_geometries(params).subscribe((data: GeoJSON.FeatureCollection) => {
-      if (cfg.clearExisting) {
-        this.removeFeatureGroup(this.sitesFeatureGroup);
-      }
+      this.replaceFeatureGroup(mode, 'sitesFeatureGroup', cfg.layerName);
 
-      this.sitesFeatureGroup = this.setMapData(
-        data,
-        onEachFeature,
-        cfg.layerName,
-        cfg.zoom,
-        effectiveStyle
+      this.storeFeatureGroup(
+        this.setMapData(
+          this.excludeFeatures(data, exclude),
+          onEachFeature,
+          cfg.layerName,
+          cfg.zoom,
+          effectiveStyle,
+          cfg.visible
+        ),
+        mode,
+        'sitesFeatureGroup',
+        cfg.layerName
       );
     });
   }
@@ -200,25 +238,38 @@ export class GeoJSONService {
     onEachFeature: Function,
     layerName: string | null,
     zoom: boolean = true,
-    style?
+    style?,
+    visible: boolean = true
   ): L.FeatureGroup | undefined {
     const map = this._mapService.getMap();
     if (geojson['features'] == null) {
       return undefined;
     }
 
+    this.watchLayerControl();
     const featureGroup: L.FeatureGroup = this._mapService.createOrderedGeojson(
       geojson,
       false,
       onEachFeature,
       style
     );
-    if (layerName) {
-      this._mapService.layerControl.addOverlay(featureGroup, layerName);
+    if (featureGroup.getLayers().length == 0) {
+      // pas d'entrée dans le gestionnaire pour une couche sans entité
+      map.removeLayer(featureGroup);
+      return undefined;
     }
-    if (zoom) {
-      map.fitBounds(featureGroup.getBounds());
-    }
+    this.asOurOwnChange(() => {
+      if (layerName) {
+        this._mapService.layerControl.addOverlay(featureGroup, layerName);
+      }
+      if (!visible) {
+        // createOrderedGeojson l'a déjà ajoutée à la carte, la retirer pour la
+        // laisser à cocher
+        map.removeLayer(featureGroup);
+      } else if (zoom) {
+        map.fitBounds(featureGroup.getBounds());
+      }
+    });
 
     return featureGroup;
   }
@@ -242,9 +293,85 @@ export class GeoJSONService {
   }
 
   removeFeatureGroup(feature: L.FeatureGroup) {
-    if (feature && this._mapService.map?.hasLayer(feature)) {
-      this._mapService.map.removeLayer(feature);
-      this._mapService.layerControl.removeLayer(feature);
+    if (!feature || !this._mapService.map) {
+      return;
+    }
+    this.asOurOwnChange(() => {
+      if (this._mapService.map.hasLayer(feature)) {
+        this._mapService.map.removeLayer(feature);
+      }
+      // couche "info_hidden" : déclarée mais pas affichée, son overlay est à retirer
+      // même absente de la carte
+      this._mapService.layerControl?.removeLayer(feature);
+    });
+  }
+
+  /** cocher ou décocher est un événement du layer Control : le capter plutôt que de
+      le déduire de l'état de la carte, remplacée quand la page change */
+  private watchLayerControl() {
+    const map = this._mapService.map;
+    if (!map || this.watchedMap === map) {
+      return;
+    }
+    this.watchedMap = map;
+    map.on('overlayadd overlayremove', (e: any) => {
+      if (!this.ownLayerChanges && e.name) {
+        this.userLayerVisibility[e.name] = e.type === 'overlayadd';
+      }
+    });
+  }
+
+  /** nos ajouts et retraits émettent les mêmes événements qu'un clic, les taire */
+  private asOurOwnChange(action: () => void) {
+    this.ownLayerChanges++;
+    try {
+      action();
+    } finally {
+      this.ownLayerChanges--;
+    }
+  }
+
+  private excludeFeatures(
+    data: GeoJSON.FeatureCollection,
+    exclude?: ExcludedFeatures
+  ): GeoJSON.FeatureCollection {
+    if (exclude?.value == null || data?.features == null) {
+      return data;
+    }
+    // comparaison souple : id de l'URL en chaîne, propriété GeoJSON en entier
+    return {
+      ...data,
+      features: data.features.filter((f) => f.properties[exclude.property] != exclude.value),
+    };
+  }
+
+  /** retire la couche que le nouvel appel remplace : donnée principale de la carte,
+      ou couche "info" de même nom */
+  private replaceFeatureGroup(
+    mode: DisplayMode,
+    mainProperty: 'sitesFeatureGroup' | 'sitesGroupFeatureGroup',
+    layerName: string | null
+  ) {
+    if (mode === 'main') {
+      this.removeFeatureGroup(this[mainProperty]);
+      return;
+    }
+    this.removeFeatureGroup(this.infoFeatureGroups[layerName]);
+    delete this.infoFeatureGroups[layerName];
+  }
+
+  private storeFeatureGroup(
+    featureGroup: L.FeatureGroup | undefined,
+    mode: DisplayMode,
+    mainProperty: 'sitesFeatureGroup' | 'sitesGroupFeatureGroup',
+    layerName: string | null
+  ) {
+    if (mode === 'main') {
+      this[mainProperty] = featureGroup;
+    } else if (featureGroup) {
+      this.infoFeatureGroups[layerName] = featureGroup;
+    } else {
+      delete this.infoFeatureGroups[layerName];
     }
   }
 
@@ -311,6 +438,7 @@ export class GeoJSONService {
     if (!this._mapService.map) {
       return;
     }
+    this.forgetInfoFeatureGroups();
     this._mapService.map.eachLayer(function (layer) {
       if (layer instanceof L.FeatureGroup) {
         listFeatureGroup.push(layer);
@@ -318,7 +446,6 @@ export class GeoJSONService {
     });
     for (const featureGroup of listFeatureGroup) {
       this.removeFeatureGroup(featureGroup);
-      this._mapService.layerControl.removeLayer(featureGroup);
     }
   }
 
@@ -329,7 +456,7 @@ export class GeoJSONService {
   /**
    * Détermine la configuration du mode d'affichage d'un layer.
    *
-   * @param mode - Type d'affichage demandé ("info", "info_zoom" ou "main")
+   * @param mode - Type d'affichage demandé ("info", "info_zoom", "info_hidden" ou "main")
    * @param layerName - Nom du layer concerné (utilisé uniquement pour les modes info)
    * @returns Un objet LayerModeConfig décrivant le comportement attendu
    */
@@ -338,34 +465,19 @@ export class GeoJSONService {
     // Modes "info" :
     // - "info"      : Affichage dans le layer Control pas de zoom automatique
     // - "info_zoom" : Affichage dans le layer Control zoom forcé sur l'entité cliquée
+    // - "info_hidden" : Ajout au layer Control sans affichage, à cocher par l'utilisateur
     // - "main"      : Affichage en tant qu'élement principal de la carte zoom forcé sur l'entité cliquée
-    if (mode === 'info' || mode === 'info_zoom') {
+    if (mode !== 'main') {
       return {
         layerName: layerName,
         zoom: mode === 'info_zoom',
-        clearExisting: this.testLayerControlExists(layerName), // test si le layer est déjà présent dans Layercontrol
+        visible: this.userLayerVisibility[layerName] ?? mode !== 'info_hidden',
       };
     }
     return {
       layerName: null,
       zoom: true,
-      clearExisting: true, // en "main", on nettoye les données à chaque appel
+      visible: true,
     };
-  }
-
-  /**
-   * Vérifie si un layer  (défini par son nom)  existe déjà
-   * dans le LayerControl de la carte.
-   *
-   * @param layerName - Nom du layer à rechercher
-   * @returns true si un overlay du LayerControl possède ce nom, sinon false
-   */
-  private testLayerControlExists(layerName: string): boolean {
-    const layers = this._mapService.layerControl?.['_layers'] ?? [];
-    const overlayNames = new Set(layers.filter((o: any) => o?.overlay).map((o: any) => o?.name));
-    if (overlayNames.has(layerName)) {
-      return true;
-    }
-    return false;
   }
 }


### PR DESCRIPTION
Fixes #547

Deux couches `Sites` et `Groupes de sites` sont ajoutées au gestionnaire de couches Leaflet des fiches détail des groupes de sites, sites, visites, observations... Elles sont décochées par défaut. Lorsqu'elles sont cochées, les autres entités sont affichées sur la carte et leur popup permet de passer de l'une à l'autre sans repasser par la page de liste. L'état de cochage de chacune des couches est conservé quand on change de fiche.

Un quatrième `DisplayMode`, `info_hidden`, déclare une couche dans le gestionnaire sans l'afficher. `clearExisting` et `testLayerControlExists` sont remplacés par un suivi des couches par nom. Le service garde donc un handle sur chaque couche info, sans ça une couche décochée ne serait jamais retirée.

Les couches « info » sont restreintes aux types de site du sous-module, via un `ConfigService.moduleTypesSite()` car la route `geometries` ne l'applique pas d'elle-même.

Deux défauts préexistants que cette fonctionnalité révèle :

`onCancelEdit` appelait `_location.back()`, ce qui renvoyait vers la dernière page affichée, qui peut maintenant être une autre fiche détail. Comme l'édition depuis une fiche n'est qu'un changement d'état, et pas de page, le retour arrière n'est gardé que là où il est pertinent : en création, et à l'arrivée en mode édition depuis la liste (icône crayon). Maintenant, annuler une édition d'une fiche détail garde l'utilisateur sur la même fiche détail.

`navigateToParent` ne traitait que le parent « module ». Après la suppression d'un site sans groupe, on atterrissait sur la liste des groupes, maintenant on arrive sur la liste des sites.